### PR TITLE
Implement User CRUD with TypeGraphQL

### DIFF
--- a/graphql-typegraphql-crud-final/prisma/schema.prisma
+++ b/graphql-typegraphql-crud-final/prisma/schema.prisma
@@ -7,11 +7,295 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Todo {
+model User {
+  id            Int            @id @default(autoincrement())
+  name          String
+  email         String         @unique
+  password      String
+  avatarUrl     String?
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+  role          String         @default("user")
+  jobTitle      String?
+  // Relations
+  audits        Audit[]        @relation("AuditCreatedBy")
+  comments      Comment[]      @relation("CommentCreatedBy")
+  companies     Company[]      @relation("CompanySalesOwner")
+  deals         Deal[]         @relation("DealSalesOwner")
+  eventsCreated Event[]        @relation("EventCreatedBy")
+  events        Event[]        @relation("EventParticipants")
+  notes         Note[]         @relation("NoteCreatedBy")
+  notifications Notification[] @relation("UserNotifications")
+  projects      Project[]      @relation("ProjectCreatedBy")
+  tokens        Token[]        @relation("UserTokens")
+  contacts      Contact[]      @relation("ContactSalesOwner")
+  tasks         Task[]         @relation("TaskUsers")
+  quotes        Quote[]        @relation("UserQuotes")
+}
+
+model Company {
+  id           Int     @id @default(autoincrement())
+  name         String
+  industry     String?
+  description  String?
+  avatarUrl    String?
+  website      String?
+  companySize  String?
+  businessType String?
+  address      String?
+  city         String?
+  country      String?
+
+  salesOwnerId Int?
+  salesOwner   User? @relation("CompanySalesOwner", fields: [salesOwnerId], references: [id])
+
+  contacts Contact[] @relation("CompanyContacts")
+  deals    Deal[]    @relation("CompanyDeals")
+  notes    Note[]    @relation("CompanyNotes")
+  quotes   Quote[]   @relation("CompanyQuotes")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Contact {
   id          Int      @id @default(autoincrement())
+  name        String
+  email       String?
+  phone       String?
+  description String?
+  companyId   Int?
+  company     Company? @relation("CompanyContacts", fields: [companyId], references: [id])
+  status      String?
+  jobTitle    String?
+  deals       Deal[]    @relation("DealContact")
+
+  salesOwnerId Int?
+  salesOwner   User?    @relation("ContactSalesOwner", fields: [salesOwnerId], references: [id])
+  quotes       Quote[]  @relation("ContactQuotes")
+  notes        Note[]   @relation("ContactNotes")
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}
+
+model Deal {
+  id          Int     @id @default(autoincrement())
+  title       String
+  amount      Float
+  description String?
+
+  stageId Int?
+  stage   DealStage? @relation("DealStage", fields: [stageId], references: [id])
+
+  companyId Int?
+  company   Company? @relation("CompanyDeals", fields: [companyId], references: [id])
+
+  contactId Int?
+  contact   Contact? @relation("DealContact", fields: [contactId], references: [id])
+
+  salesOwnerId Int?
+  salesOwner   User?    @relation("DealSalesOwner", fields: [salesOwnerId], references: [id])
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}
+
+model DealStage {
+  id    Int    @id @default(autoincrement())
+  title String
+  order Int    @default(0)
+  color String @default("gray")
+
+  deals Deal[] @relation("DealStage")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model TaskStage {
+  id    Int    @id @default(autoincrement())
+  title String
+  order Int    @default(0)
+  color String @default("gray")
+  tasks Task[] @relation("TaskStage")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Checklist {
+  id        Int      @id @default(autoincrement())
+  title     String
+  checked   Boolean  @default(false)
+  taskId    Int
+  task      Task     @relation("TaskChecklists", fields: [taskId], references: [id])
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Task {
+  id          Int       @id @default(autoincrement())
+  title       String
+  description String?   @default("")
+  status      String    @default("todo")
+  dueDate     DateTime?
+  completed   Boolean   @default(false)
+
+  stageId Int?
+  stage   TaskStage? @relation("TaskStage", fields: [stageId], references: [id])
+
+  projectId  Int?
+  project    Project?    @relation(fields: [projectId], references: [id])
+  users      User[]      @relation("TaskUsers")
+  checklists Checklist[] @relation("TaskChecklists")
+  comments   Comment[]   @relation("TaskComments")
+  createdAt  DateTime    @default(now())
+  updatedAt  DateTime    @updatedAt
+}
+
+model Category {
+  id    Int    @id @default(autoincrement())
+  title String
+  products Product[] @relation("ProductCategory")
+}
+
+model Product {
+  id          Int      @id @default(autoincrement())
+  name        String
+  description String?
+  price       Float
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+  quotes      Quote[]  @relation("QuoteProducts")
+  categoryId  Int?
+  category    Category? @relation("ProductCategory", fields: [categoryId], references: [id])
+}
+
+model Quote {
+  id          Int       @id @default(autoincrement())
   title       String
-  content     String?
-  completedAt DateTime?
+  status      String    @default("DRAFT")
+  description String?
+  subTotal    Float
+  total       Float
+  tax         Float     @default(0)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  items       Product[] @relation("QuoteProducts")
+  companyId   Int?
+  company     Company?  @relation("CompanyQuotes", fields: [companyId], references: [id])
+
+  salesOwnerId Int?
+  salesOwner   User? @relation("UserQuotes", fields: [salesOwnerId], references: [id])
+
+  contactId Int?
+  contact   Contact? @relation("ContactQuotes", fields: [contactId], references: [id])
+}
+
+model Project {
+  id          Int     @id @default(autoincrement())
+  name        String
+  description String?
+
+  createdById Int?
+  createdBy   User? @relation("ProjectCreatedBy", fields: [createdById], references: [id])
+
+  tasks Task[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Event {
+  id          Int       @id @default(autoincrement())
+  title       String
+  startDate   DateTime
+  endDate     DateTime?
+  description String?
+  color       String?
+
+  createdById Int?
+  createdBy   User? @relation("EventCreatedBy", fields: [createdById], references: [id])
+
+  categoryId Int?
+  category   EventCategory? @relation("EventCategory", fields: [categoryId], references: [id])
+
+  participants User[] @relation("EventParticipants")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model EventCategory {
+  id    Int    @id @default(autoincrement())
+  title String
+
+  events Event[] @relation("EventCategory")
+}
+
+model Note {
+  id   Int    @id @default(autoincrement())
+  note String
+
+  companyId Int?
+  company   Company? @relation("CompanyNotes", fields: [companyId], references: [id])
+
+  contactId Int?
+  contact   Contact? @relation("ContactNotes", fields: [contactId], references: [id])
+
+  createdById Int?
+  createdBy   User? @relation("NoteCreatedBy", fields: [createdById], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Notification {
+  id      Int     @id @default(autoincrement())
+  title   String
+  message String
+  read    Boolean @default(false)
+
+  userId Int
+  user   User @relation("UserNotifications", fields: [userId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Token {
+  id          Int      @id @default(autoincrement())
+  token       String   @unique
+  type        String
+  expires     DateTime
+  blacklisted Boolean  @default(false)
+
+  userId Int
+  user   User @relation("UserTokens", fields: [userId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Comment {
+  id        Int      @id @default(autoincrement())
+  comment   String
+  createdById    Int
+  createdBy User     @relation("CommentCreatedBy", fields: [createdById], references: [id])
+  taskId    Int?
+  task      Task?    @relation("TaskComments", fields: [taskId], references: [id])
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Audit {
+  id           Int      @id @default(autoincrement())
+  action       String
+  targetEntity String
+  targetId     Int
+  changes      Json
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  userId Int?
+  user   User? @relation("AuditCreatedBy", fields: [userId], references: [id])
 }

--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -3,12 +3,13 @@ import { ApolloServer } from "apollo-server"
 import { buildSchema } from "type-graphql"
 import { PrismaClient } from "@prisma/client"
 import { TodoResolver } from "./resolvers/TodoResolver"
+import { UserResolver } from "./resolvers/UserResolver"
 
 const prisma = new PrismaClient()
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [TodoResolver],
+    resolvers: [TodoResolver, UserResolver],
     validate: false,
   })
 

--- a/graphql-typegraphql-crud-final/src/resolvers/UserResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/UserResolver.ts
@@ -1,0 +1,37 @@
+import { Arg, Int, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { User, CreateUserInput, UpdateUserInput } from "../schema/User";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => User)
+export class UserResolver {
+  @Query(() => [User])
+  async users() {
+    return prisma.user.findMany();
+  }
+
+  @Query(() => User, { nullable: true })
+  async user(@Arg("id", () => Int) id: number) {
+    return prisma.user.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => User)
+  async createUser(@Arg("data") data: CreateUserInput) {
+    return prisma.user.create({ data });
+  }
+
+  @Mutation(() => User, { nullable: true })
+  async updateUser(
+    @Arg("id", () => Int) id: number,
+    @Arg("data") data: UpdateUserInput
+  ) {
+    return prisma.user.update({ where: { id }, data });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteUser(@Arg("id", () => Int) id: number) {
+    await prisma.user.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/User.ts
+++ b/graphql-typegraphql-crud-final/src/schema/User.ts
@@ -1,0 +1,70 @@
+import { Field, ID, ObjectType, InputType } from "type-graphql";
+
+@ObjectType()
+export class User {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  name: string;
+
+  @Field()
+  email: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field()
+  role: string;
+
+  @Field({ nullable: true })
+  jobTitle?: string;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}
+
+@InputType()
+export class CreateUserInput {
+  @Field()
+  name: string;
+
+  @Field()
+  email: string;
+
+  @Field()
+  password: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field({ nullable: true })
+  role?: string;
+
+  @Field({ nullable: true })
+  jobTitle?: string;
+}
+
+@InputType()
+export class UpdateUserInput {
+  @Field({ nullable: true })
+  name?: string;
+
+  @Field({ nullable: true })
+  email?: string;
+
+  @Field({ nullable: true })
+  password?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field({ nullable: true })
+  role?: string;
+
+  @Field({ nullable: true })
+  jobTitle?: string;
+}


### PR DESCRIPTION
## Summary
- add `User` schema with input types
- implement `UserResolver` for CRUD operations
- register `UserResolver` in the server

## Testing
- `npm test` *(fails: Missing script)*