### PR TITLE
Add Company CRUD

### DIFF
--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -4,12 +4,13 @@ import { buildSchema } from "type-graphql"
 import { PrismaClient } from "@prisma/client"
 import { TodoResolver } from "./resolvers/TodoResolver"
 import { UserResolver } from "./resolvers/UserResolver"
+import { CompanyResolver } from "./resolvers/CompanyResolver"
 
 const prisma = new PrismaClient()
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [TodoResolver, UserResolver],
+    resolvers: [TodoResolver, UserResolver, CompanyResolver],
     validate: false,
   })
 

--- a/graphql-typegraphql-crud-final/src/resolvers/CompanyResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/CompanyResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { Company } from "../schema/Company";
+import { CreateCompanyInput, UpdateCompanyInput } from "../schema/CompanyInput";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => Company)
+export class CompanyResolver {
+  @Query(() => [Company])
+  async companies() {
+    return prisma.company.findMany();
+  }
+
+  @Query(() => Company, { nullable: true })
+  async company(@Arg("id", () => ID) id: number) {
+    return prisma.company.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => Company)
+  async createCompany(@Arg("data") data: CreateCompanyInput) {
+    return prisma.company.create({ data });
+  }
+
+  @Mutation(() => Company, { nullable: true })
+  async updateCompany(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateCompanyInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateCompanyInput;
+    return prisma.company.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteCompany(@Arg("id", () => ID) id: number) {
+    await prisma.company.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/Company.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Company.ts
@@ -1,0 +1,46 @@
+import { Field, ID, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class Company {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  industry?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field({ nullable: true })
+  website?: string;
+
+  @Field({ nullable: true })
+  companySize?: string;
+
+  @Field({ nullable: true })
+  businessType?: string;
+
+  @Field({ nullable: true })
+  address?: string;
+
+  @Field({ nullable: true })
+  city?: string;
+
+  @Field({ nullable: true })
+  country?: string;
+
+  @Field({ nullable: true })
+  salesOwnerId?: number;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}

--- a/graphql-typegraphql-crud-final/src/schema/CompanyInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/CompanyInput.ts
@@ -1,0 +1,73 @@
+import { InputType, Field } from "type-graphql";
+
+@InputType()
+export class CreateCompanyInput {
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  industry?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field({ nullable: true })
+  website?: string;
+
+  @Field({ nullable: true })
+  companySize?: string;
+
+  @Field({ nullable: true })
+  businessType?: string;
+
+  @Field({ nullable: true })
+  address?: string;
+
+  @Field({ nullable: true })
+  city?: string;
+
+  @Field({ nullable: true })
+  country?: string;
+
+  @Field({ nullable: true })
+  salesOwnerId?: number;
+}
+
+@InputType()
+export class UpdateCompanyInput {
+  @Field({ nullable: true })
+  name?: string;
+
+  @Field({ nullable: true })
+  industry?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field({ nullable: true })
+  website?: string;
+
+  @Field({ nullable: true })
+  companySize?: string;
+
+  @Field({ nullable: true })
+  businessType?: string;
+
+  @Field({ nullable: true })
+  address?: string;
+
+  @Field({ nullable: true })
+  city?: string;
+
+  @Field({ nullable: true })
+  country?: string;
+
+  @Field({ nullable: true })
+  salesOwnerId?: number;
+}


### PR DESCRIPTION
## Summary
- add Company GraphQL object and inputs
- implement CompanyResolver with CRUD operations
- register resolver in the schema builder

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'apollo-server')*