### PR TITLE
Add Contact model CRUD

### DIFF
--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -4,12 +4,14 @@ import { buildSchema } from "type-graphql"
 import { PrismaClient } from "@prisma/client"
 import { TodoResolver } from "./resolvers/TodoResolver"
 import { UserResolver } from "./resolvers/UserResolver"
+import { CompanyResolver } from "./resolvers/CompanyResolver"
+import { ContactResolver } from "./resolvers/ContactResolver"
 
 const prisma = new PrismaClient()
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [TodoResolver, UserResolver],
+    resolvers: [TodoResolver, UserResolver, CompanyResolver, ContactResolver],
     validate: false,
   })
 

--- a/graphql-typegraphql-crud-final/src/resolvers/CompanyResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/CompanyResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { Company } from "../schema/Company";
+import { CreateCompanyInput, UpdateCompanyInput } from "../schema/CompanyInput";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => Company)
+export class CompanyResolver {
+  @Query(() => [Company])
+  async companies() {
+    return prisma.company.findMany();
+  }
+
+  @Query(() => Company, { nullable: true })
+  async company(@Arg("id", () => ID) id: number) {
+    return prisma.company.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => Company)
+  async createCompany(@Arg("data") data: CreateCompanyInput) {
+    return prisma.company.create({ data });
+  }
+
+  @Mutation(() => Company, { nullable: true })
+  async updateCompany(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateCompanyInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateCompanyInput;
+    return prisma.company.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteCompany(@Arg("id", () => ID) id: number) {
+    await prisma.company.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/resolvers/ContactResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/ContactResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { Contact } from "../schema/Contact";
+import { CreateContactInput, UpdateContactInput } from "../schema/ContactInput";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => Contact)
+export class ContactResolver {
+  @Query(() => [Contact])
+  async contacts() {
+    return prisma.contact.findMany();
+  }
+
+  @Query(() => Contact, { nullable: true })
+  async contact(@Arg("id", () => ID) id: number) {
+    return prisma.contact.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => Contact)
+  async createContact(@Arg("data") data: CreateContactInput) {
+    return prisma.contact.create({ data });
+  }
+
+  @Mutation(() => Contact, { nullable: true })
+  async updateContact(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateContactInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateContactInput;
+    return prisma.contact.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteContact(@Arg("id", () => ID) id: number) {
+    await prisma.contact.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/Company.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Company.ts
@@ -1,0 +1,46 @@
+import { Field, ID, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class Company {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  industry?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field({ nullable: true })
+  website?: string;
+
+  @Field({ nullable: true })
+  companySize?: string;
+
+  @Field({ nullable: true })
+  businessType?: string;
+
+  @Field({ nullable: true })
+  address?: string;
+
+  @Field({ nullable: true })
+  city?: string;
+
+  @Field({ nullable: true })
+  country?: string;
+
+  @Field({ nullable: true })
+  salesOwnerId?: number;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}

--- a/graphql-typegraphql-crud-final/src/schema/CompanyInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/CompanyInput.ts
@@ -1,0 +1,73 @@
+import { InputType, Field } from "type-graphql";
+
+@InputType()
+export class CreateCompanyInput {
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  industry?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field({ nullable: true })
+  website?: string;
+
+  @Field({ nullable: true })
+  companySize?: string;
+
+  @Field({ nullable: true })
+  businessType?: string;
+
+  @Field({ nullable: true })
+  address?: string;
+
+  @Field({ nullable: true })
+  city?: string;
+
+  @Field({ nullable: true })
+  country?: string;
+
+  @Field({ nullable: true })
+  salesOwnerId?: number;
+}
+
+@InputType()
+export class UpdateCompanyInput {
+  @Field({ nullable: true })
+  name?: string;
+
+  @Field({ nullable: true })
+  industry?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field({ nullable: true })
+  website?: string;
+
+  @Field({ nullable: true })
+  companySize?: string;
+
+  @Field({ nullable: true })
+  businessType?: string;
+
+  @Field({ nullable: true })
+  address?: string;
+
+  @Field({ nullable: true })
+  city?: string;
+
+  @Field({ nullable: true })
+  country?: string;
+
+  @Field({ nullable: true })
+  salesOwnerId?: number;
+}

--- a/graphql-typegraphql-crud-final/src/schema/Contact.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Contact.ts
@@ -1,0 +1,37 @@
+import { Field, ID, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class Contact {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  email?: string;
+
+  @Field({ nullable: true })
+  phone?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  companyId?: number;
+
+  @Field({ nullable: true })
+  status?: string;
+
+  @Field({ nullable: true })
+  jobTitle?: string;
+
+  @Field({ nullable: true })
+  salesOwnerId?: number;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}

--- a/graphql-typegraphql-crud-final/src/schema/ContactInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/ContactInput.ts
@@ -1,0 +1,55 @@
+import { Field, InputType } from "type-graphql";
+
+@InputType()
+export class CreateContactInput {
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  email?: string;
+
+  @Field({ nullable: true })
+  phone?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  companyId?: number;
+
+  @Field({ nullable: true })
+  status?: string;
+
+  @Field({ nullable: true })
+  jobTitle?: string;
+
+  @Field({ nullable: true })
+  salesOwnerId?: number;
+}
+
+@InputType()
+export class UpdateContactInput {
+  @Field({ nullable: true })
+  name?: string;
+
+  @Field({ nullable: true })
+  email?: string;
+
+  @Field({ nullable: true })
+  phone?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  companyId?: number;
+
+  @Field({ nullable: true })
+  status?: string;
+
+  @Field({ nullable: true })
+  jobTitle?: string;
+
+  @Field({ nullable: true })
+  salesOwnerId?: number;
+}


### PR DESCRIPTION
## Summary
- implement GraphQL object, inputs and resolver for `Contact`
- register the resolver in the GraphQL schema

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'apollo-server')*