### PR TITLE
Add Project CRUD

### DIFF
--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -6,12 +6,19 @@ import { TodoResolver } from "./resolvers/TodoResolver";
 import { UserResolver } from "./resolvers/UserResolver";
 import { CompanyResolver } from "./resolvers/CompanyResolver";
 import { ContactResolver } from "./resolvers/ContactResolver";
+import { ProjectResolver } from "./resolvers/ProjectResolver";
 
 const prisma = new PrismaClient();
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [TodoResolver, UserResolver, CompanyResolver, ContactResolver],
+    resolvers: [
+      TodoResolver,
+      UserResolver,
+      CompanyResolver,
+      ContactResolver,
+      ProjectResolver,
+    ],
     validate: false,
   });
 

--- a/graphql-typegraphql-crud-final/src/resolvers/ProjectResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/ProjectResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { Project } from "../schema/Project";
+import { CreateProjectInput, UpdateProjectInput } from "../schema/ProjectInput";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => Project)
+export class ProjectResolver {
+  @Query(() => [Project])
+  async projects() {
+    return prisma.project.findMany();
+  }
+
+  @Query(() => Project, { nullable: true })
+  async project(@Arg("id", () => ID) id: number) {
+    return prisma.project.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => Project)
+  async createProject(@Arg("data") data: CreateProjectInput) {
+    return prisma.project.create({ data });
+  }
+
+  @Mutation(() => Project, { nullable: true })
+  async updateProject(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateProjectInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateProjectInput;
+    return prisma.project.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteProject(@Arg("id", () => ID) id: number) {
+    await prisma.project.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/Project.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Project.ts
@@ -1,0 +1,22 @@
+import { Field, ID, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class Project {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  createdById?: number;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}

--- a/graphql-typegraphql-crud-final/src/schema/ProjectInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/ProjectInput.ts
@@ -1,0 +1,25 @@
+import { InputType, Field } from "type-graphql";
+
+@InputType()
+export class CreateProjectInput {
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  createdById?: number;
+}
+
+@InputType()
+export class UpdateProjectInput {
+  @Field({ nullable: true })
+  name?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  createdById?: number;
+}


### PR DESCRIPTION
## Summary
- define `Project` model in GraphQL schema
- add inputs for creating/updating projects
- implement `ProjectResolver`
- register resolver in the application

## Testing
- `tsc --noEmit` *(fails: Cannot find module 'apollo-server' ...)*