### PR TITLE
Add CRUD for TaskStage

### DIFF
--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -6,12 +6,19 @@ import { TodoResolver } from "./resolvers/TodoResolver";
 import { UserResolver } from "./resolvers/UserResolver";
 import { CompanyResolver } from "./resolvers/CompanyResolver";
 import { ContactResolver } from "./resolvers/ContactResolver";
+import { TaskStageResolver } from "./resolvers/TaskStageResolver";
 
 const prisma = new PrismaClient();
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [TodoResolver, UserResolver, CompanyResolver, ContactResolver],
+    resolvers: [
+      TodoResolver,
+      UserResolver,
+      CompanyResolver,
+      ContactResolver,
+      TaskStageResolver,
+    ],
     validate: false,
   });
 

--- a/graphql-typegraphql-crud-final/src/resolvers/TaskStageResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/TaskStageResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { TaskStage } from "../schema/TaskStage";
+import { CreateTaskStageInput, UpdateTaskStageInput } from "../schema/TaskStageInput";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => TaskStage)
+export class TaskStageResolver {
+  @Query(() => [TaskStage])
+  async taskStages() {
+    return prisma.taskStage.findMany();
+  }
+
+  @Query(() => TaskStage, { nullable: true })
+  async taskStage(@Arg("id", () => ID) id: number) {
+    return prisma.taskStage.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => TaskStage)
+  async createTaskStage(@Arg("data") data: CreateTaskStageInput) {
+    return prisma.taskStage.create({ data });
+  }
+
+  @Mutation(() => TaskStage, { nullable: true })
+  async updateTaskStage(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateTaskStageInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateTaskStageInput;
+    return prisma.taskStage.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteTaskStage(@Arg("id", () => ID) id: number) {
+    await prisma.taskStage.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/TaskStage.ts
+++ b/graphql-typegraphql-crud-final/src/schema/TaskStage.ts
@@ -1,0 +1,22 @@
+import { Field, ID, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class TaskStage {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  title: string;
+
+  @Field()
+  order: number;
+
+  @Field()
+  color: string;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}

--- a/graphql-typegraphql-crud-final/src/schema/TaskStageInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/TaskStageInput.ts
@@ -1,0 +1,25 @@
+import { Field, InputType } from "type-graphql";
+
+@InputType()
+export class CreateTaskStageInput {
+  @Field()
+  title: string;
+
+  @Field({ nullable: true })
+  order?: number;
+
+  @Field({ nullable: true })
+  color?: string;
+}
+
+@InputType()
+export class UpdateTaskStageInput {
+  @Field({ nullable: true })
+  title?: string;
+
+  @Field({ nullable: true })
+  order?: number;
+
+  @Field({ nullable: true })
+  color?: string;
+}


### PR DESCRIPTION
## Summary
- add TaskStage schema and inputs
- implement resolver for TaskStage with queries and mutations
- register TaskStageResolver in Apollo server

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'apollo-server')*