### PR TITLE
Add Product CRUD to GraphQL API

### DIFF
--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -6,12 +6,19 @@ import { TodoResolver } from "./resolvers/TodoResolver";
 import { UserResolver } from "./resolvers/UserResolver";
 import { CompanyResolver } from "./resolvers/CompanyResolver";
 import { ContactResolver } from "./resolvers/ContactResolver";
+import { ProductResolver } from "./resolvers/ProductResolver";
 
 const prisma = new PrismaClient();
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [TodoResolver, UserResolver, CompanyResolver, ContactResolver],
+    resolvers: [
+      TodoResolver,
+      UserResolver,
+      CompanyResolver,
+      ContactResolver,
+      ProductResolver,
+    ],
     validate: false,
   });
 

--- a/graphql-typegraphql-crud-final/src/resolvers/ProductResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/ProductResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { Product } from "../schema/Product";
+import { CreateProductInput, UpdateProductInput } from "../schema/ProductInput";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => Product)
+export class ProductResolver {
+  @Query(() => [Product])
+  async products() {
+    return prisma.product.findMany();
+  }
+
+  @Query(() => Product, { nullable: true })
+  async product(@Arg("id", () => ID) id: number) {
+    return prisma.product.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => Product)
+  async createProduct(@Arg("data") data: CreateProductInput) {
+    return prisma.product.create({ data });
+  }
+
+  @Mutation(() => Product, { nullable: true })
+  async updateProduct(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateProductInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateProductInput;
+    return prisma.product.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteProduct(@Arg("id", () => ID) id: number) {
+    await prisma.product.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/Product.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Product.ts
@@ -1,0 +1,25 @@
+import { Field, ID, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class Product {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field()
+  price: number;
+
+  @Field({ nullable: true })
+  categoryId?: number;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}

--- a/graphql-typegraphql-crud-final/src/schema/ProductInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/ProductInput.ts
@@ -1,0 +1,31 @@
+import { Field, InputType } from "type-graphql";
+
+@InputType()
+export class CreateProductInput {
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field()
+  price: number;
+
+  @Field({ nullable: true })
+  categoryId?: number;
+}
+
+@InputType()
+export class UpdateProductInput {
+  @Field({ nullable: true })
+  name?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  price?: number;
+
+  @Field({ nullable: true })
+  categoryId?: number;
+}


### PR DESCRIPTION
## Summary
- add `Product` GraphQL object type
- add input types for creating and updating products
- implement resolver with full CRUD operations
- register `ProductResolver` in the server

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'apollo-server' or its corresponding type declarations)*