### PR TITLE
Add Category GraphQL CRUD

### DIFF
--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -6,12 +6,19 @@ import { TodoResolver } from "./resolvers/TodoResolver";
 import { UserResolver } from "./resolvers/UserResolver";
 import { CompanyResolver } from "./resolvers/CompanyResolver";
 import { ContactResolver } from "./resolvers/ContactResolver";
+import { CategoryResolver } from "./resolvers/CategoryResolver";
 
 const prisma = new PrismaClient();
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [TodoResolver, UserResolver, CompanyResolver, ContactResolver],
+    resolvers: [
+      TodoResolver,
+      UserResolver,
+      CompanyResolver,
+      ContactResolver,
+      CategoryResolver,
+    ],
     validate: false,
   });
 

--- a/graphql-typegraphql-crud-final/src/resolvers/CategoryResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/CategoryResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { Category } from "../schema/Category";
+import { CreateCategoryInput, UpdateCategoryInput } from "../schema/CategoryInput";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => Category)
+export class CategoryResolver {
+  @Query(() => [Category])
+  async categories() {
+    return prisma.category.findMany();
+  }
+
+  @Query(() => Category, { nullable: true })
+  async category(@Arg("id", () => ID) id: number) {
+    return prisma.category.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => Category)
+  async createCategory(@Arg("data") data: CreateCategoryInput) {
+    return prisma.category.create({ data });
+  }
+
+  @Mutation(() => Category, { nullable: true })
+  async updateCategory(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateCategoryInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateCategoryInput;
+    return prisma.category.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteCategory(@Arg("id", () => ID) id: number) {
+    await prisma.category.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/Category.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Category.ts
@@ -1,0 +1,10 @@
+import { Field, ID, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class Category {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  title: string;
+}

--- a/graphql-typegraphql-crud-final/src/schema/CategoryInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/CategoryInput.ts
@@ -1,0 +1,13 @@
+import { Field, InputType } from "type-graphql";
+
+@InputType()
+export class CreateCategoryInput {
+  @Field()
+  title: string;
+}
+
+@InputType()
+export class UpdateCategoryInput {
+  @Field({ nullable: true })
+  title?: string;
+}


### PR DESCRIPTION
## Summary
- add `CategoryResolver` for Prisma Category model operations
- create `Category` object type and input types for TypeGraphQL
- register `CategoryResolver` in the Apollo server setup

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'apollo-server' or its corresponding type declarations)*