### PR TITLE
Add Audit CRUD with TypeGraphQL

### DIFF
--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -6,12 +6,19 @@ import { TodoResolver } from "./resolvers/TodoResolver";
 import { UserResolver } from "./resolvers/UserResolver";
 import { CompanyResolver } from "./resolvers/CompanyResolver";
 import { ContactResolver } from "./resolvers/ContactResolver";
+import { AuditResolver } from "./resolvers/AuditResolver";
 
 const prisma = new PrismaClient();
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [TodoResolver, UserResolver, CompanyResolver, ContactResolver],
+    resolvers: [
+      TodoResolver,
+      UserResolver,
+      CompanyResolver,
+      ContactResolver,
+      AuditResolver,
+    ],
     validate: false,
   });
 

--- a/graphql-typegraphql-crud-final/src/resolvers/AuditResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/AuditResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { Audit } from "../schema/Audit";
+import { CreateAuditInput, UpdateAuditInput } from "../schema/AuditInput";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => Audit)
+export class AuditResolver {
+  @Query(() => [Audit])
+  async audits() {
+    return prisma.audit.findMany();
+  }
+
+  @Query(() => Audit, { nullable: true })
+  async audit(@Arg("id", () => ID) id: number) {
+    return prisma.audit.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => Audit)
+  async createAudit(@Arg("data") data: CreateAuditInput) {
+    return prisma.audit.create({ data });
+  }
+
+  @Mutation(() => Audit, { nullable: true })
+  async updateAudit(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateAuditInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateAuditInput;
+    return prisma.audit.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteAudit(@Arg("id", () => ID) id: number) {
+    await prisma.audit.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/Audit.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Audit.ts
@@ -1,0 +1,28 @@
+import { Field, ID, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class Audit {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  action: string;
+
+  @Field()
+  targetEntity: string;
+
+  @Field()
+  targetId: number;
+
+  @Field()
+  changes: string;
+
+  @Field({ nullable: true })
+  userId?: number;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}

--- a/graphql-typegraphql-crud-final/src/schema/AuditInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/AuditInput.ts
@@ -1,0 +1,37 @@
+import { InputType, Field } from "type-graphql";
+
+@InputType()
+export class CreateAuditInput {
+  @Field()
+  action: string;
+
+  @Field()
+  targetEntity: string;
+
+  @Field()
+  targetId: number;
+
+  @Field()
+  changes: string;
+
+  @Field({ nullable: true })
+  userId?: number;
+}
+
+@InputType()
+export class UpdateAuditInput {
+  @Field({ nullable: true })
+  action?: string;
+
+  @Field({ nullable: true })
+  targetEntity?: string;
+
+  @Field({ nullable: true })
+  targetId?: number;
+
+  @Field({ nullable: true })
+  changes?: string;
+
+  @Field({ nullable: true })
+  userId?: number;
+}


### PR DESCRIPTION
## Summary
- implement `Audit` object type and input types
- add resolver providing CRUD mutations and queries
- register the resolver in the application

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'type-graphql', '@prisma/client', etc.)*