### PR TITLE
Implement Note CRUD with TypeGraphQL

### DIFF
--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -6,12 +6,19 @@ import { TodoResolver } from "./resolvers/TodoResolver";
 import { UserResolver } from "./resolvers/UserResolver";
 import { CompanyResolver } from "./resolvers/CompanyResolver";
 import { ContactResolver } from "./resolvers/ContactResolver";
+import { NoteResolver } from "./resolvers/NoteResolver";
 
 const prisma = new PrismaClient();
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [TodoResolver, UserResolver, CompanyResolver, ContactResolver],
+    resolvers: [
+      TodoResolver,
+      UserResolver,
+      CompanyResolver,
+      ContactResolver,
+      NoteResolver,
+    ],
     validate: false,
   });
 

--- a/graphql-typegraphql-crud-final/src/resolvers/NoteResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/NoteResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { Note } from "../schema/Note";
+import { CreateNoteInput, UpdateNoteInput } from "../schema/NoteInput";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => Note)
+export class NoteResolver {
+  @Query(() => [Note])
+  async notes() {
+    return prisma.note.findMany();
+  }
+
+  @Query(() => Note, { nullable: true })
+  async note(@Arg("id", () => ID) id: number) {
+    return prisma.note.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => Note)
+  async createNote(@Arg("data") data: CreateNoteInput) {
+    return prisma.note.create({ data });
+  }
+
+  @Mutation(() => Note, { nullable: true })
+  async updateNote(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateNoteInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateNoteInput;
+    return prisma.note.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteNote(@Arg("id", () => ID) id: number) {
+    await prisma.note.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/Note.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Note.ts
@@ -1,0 +1,25 @@
+import { Field, ID, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class Note {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  note: string;
+
+  @Field({ nullable: true })
+  companyId?: number;
+
+  @Field({ nullable: true })
+  contactId?: number;
+
+  @Field({ nullable: true })
+  createdById?: number;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}

--- a/graphql-typegraphql-crud-final/src/schema/NoteInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/NoteInput.ts
@@ -1,0 +1,31 @@
+import { Field, InputType } from "type-graphql";
+
+@InputType()
+export class CreateNoteInput {
+  @Field()
+  note: string;
+
+  @Field({ nullable: true })
+  companyId?: number;
+
+  @Field({ nullable: true })
+  contactId?: number;
+
+  @Field({ nullable: true })
+  createdById?: number;
+}
+
+@InputType()
+export class UpdateNoteInput {
+  @Field({ nullable: true })
+  note?: string;
+
+  @Field({ nullable: true })
+  companyId?: number;
+
+  @Field({ nullable: true })
+  contactId?: number;
+
+  @Field({ nullable: true })
+  createdById?: number;
+}


### PR DESCRIPTION
## Summary
- define Note schema and input types
- add Note resolver with CRUD operations
- register NoteResolver in the server bootstrap

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'type-graphql', '@prisma/client', etc.)*