### PR TITLE
Add Token CRUD support

### DIFF
--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -6,12 +6,19 @@ import { TodoResolver } from "./resolvers/TodoResolver";
 import { UserResolver } from "./resolvers/UserResolver";
 import { CompanyResolver } from "./resolvers/CompanyResolver";
 import { ContactResolver } from "./resolvers/ContactResolver";
+import { TokenResolver } from "./resolvers/TokenResolver";
 
 const prisma = new PrismaClient();
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [TodoResolver, UserResolver, CompanyResolver, ContactResolver],
+    resolvers: [
+      TodoResolver,
+      UserResolver,
+      CompanyResolver,
+      ContactResolver,
+      TokenResolver,
+    ],
     validate: false,
   });
 

--- a/graphql-typegraphql-crud-final/src/resolvers/TokenResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/TokenResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { Token, CreateTokenInput, UpdateTokenInput } from "../schema/Token";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => Token)
+export class TokenResolver {
+  @Query(() => [Token])
+  async tokens() {
+    return prisma.token.findMany();
+  }
+
+  @Query(() => Token, { nullable: true })
+  async token(@Arg("id", () => ID) id: number) {
+    return prisma.token.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => Token)
+  async createToken(@Arg("data") data: CreateTokenInput) {
+    return prisma.token.create({ data });
+  }
+
+  @Mutation(() => Token, { nullable: true })
+  async updateToken(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateTokenInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateTokenInput;
+
+    return prisma.token.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deleteToken(@Arg("id", () => ID) id: number) {
+    await prisma.token.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/Token.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Token.ts
@@ -1,0 +1,64 @@
+import { Field, ID, ObjectType, InputType } from "type-graphql";
+
+@ObjectType()
+export class Token {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  token: string;
+
+  @Field()
+  type: string;
+
+  @Field()
+  expires: Date;
+
+  @Field()
+  blacklisted: boolean;
+
+  @Field()
+  userId: number;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}
+
+@InputType()
+export class CreateTokenInput {
+  @Field()
+  token: string;
+
+  @Field()
+  type: string;
+
+  @Field()
+  expires: Date;
+
+  @Field({ nullable: true })
+  blacklisted?: boolean;
+
+  @Field()
+  userId: number;
+}
+
+@InputType()
+export class UpdateTokenInput {
+  @Field({ nullable: true })
+  token?: string;
+
+  @Field({ nullable: true })
+  type?: string;
+
+  @Field({ nullable: true })
+  expires?: Date;
+
+  @Field({ nullable: true })
+  blacklisted?: boolean;
+
+  @Field({ nullable: true })
+  userId?: number;
+}


### PR DESCRIPTION
## Summary
- add Token schema with inputs
- implement TokenResolver for full CRUD
- register TokenResolver in the server

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'apollo-server' and other type declarations)*