### PR TITLE
Implement full CRUD for Todo

### DIFF
--- a/graphql-typegraphql-crud-final/prisma/schema.prisma
+++ b/graphql-typegraphql-crud-final/prisma/schema.prisma
@@ -299,3 +299,12 @@ model Audit {
   userId Int?
   user   User? @relation("AuditCreatedBy", fields: [userId], references: [id])
 }
+
+model Todo {
+  id          Int      @id @default(autoincrement())
+  title       String
+  content     String?
+  completedAt DateTime?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/graphql-typegraphql-crud-final/src/resolvers/TodoResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/TodoResolver.ts
@@ -1,23 +1,42 @@
-import { Arg, Mutation, Query, Resolver } from "type-graphql"
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql"
 import { PrismaClient } from "@prisma/client"
 import { Todo } from "../schema/Todo"
+import { CreateTodoInput, UpdateTodoInput } from "../schema/TodoInput"
 
 const prisma = new PrismaClient()
 
-@Resolver(of => Todo)
+@Resolver(() => Todo)
 export class TodoResolver {
   @Query(() => [Todo])
   async todos() {
     return prisma.todo.findMany()
   }
 
+  @Query(() => Todo, { nullable: true })
+  async todo(@Arg("id", () => ID) id: number) {
+    return prisma.todo.findUnique({ where: { id } })
+  }
+
   @Mutation(() => Todo)
-  async createTodo(
-    @Arg("title") title: string,
-    @Arg("content", { nullable: true }) content: string
+  async createTodo(@Arg("data") data: CreateTodoInput) {
+    return prisma.todo.create({ data })
+  }
+
+  @Mutation(() => Todo, { nullable: true })
+  async updateTodo(
+    @Arg("id", () => ID) id: number,
+    @Arg("data") data: UpdateTodoInput
   ) {
-    return prisma.todo.create({
-      data: { title, content },
-    })
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdateTodoInput
+
+    return prisma.todo.update({ where: { id }, data: updateData })
+  }
+
+  @Mutation(() => Boolean)
+  async deleteTodo(@Arg("id", () => ID) id: number) {
+    await prisma.todo.delete({ where: { id } })
+    return true
   }
 }

--- a/graphql-typegraphql-crud-final/src/schema/TodoInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/TodoInput.ts
@@ -1,0 +1,25 @@
+import { Field, InputType } from "type-graphql";
+
+@InputType()
+export class CreateTodoInput {
+  @Field()
+  title: string;
+
+  @Field({ nullable: true })
+  content?: string;
+
+  @Field({ nullable: true })
+  completedAt?: Date;
+}
+
+@InputType()
+export class UpdateTodoInput {
+  @Field({ nullable: true })
+  title?: string;
+
+  @Field({ nullable: true })
+  content?: string;
+
+  @Field({ nullable: true })
+  completedAt?: Date;
+}


### PR DESCRIPTION
## Summary
- add `TodoInput` definitions for create/update
- implement full CRUD operations in `TodoResolver`
- define `Todo` model in Prisma schema

## Testing
- `npx prisma generate` *(fails: EHOSTUNREACH)*