### PR TITLE
Connect CRM example to local GraphQL server

### DIFF
--- a/frontend-graphql/app-crm/codegen.ts
+++ b/frontend-graphql/app-crm/codegen.ts
@@ -1,7 +1,7 @@
 import type { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
-  schema: "https://api.crm.refine.dev/graphql",
+  schema: "http://localhost:8000",
   generates: {
     "./src/interfaces/graphql.ts": {
       plugins: ["typescript"],

--- a/frontend-graphql/app-crm/graphql.config.ts
+++ b/frontend-graphql/app-crm/graphql.config.ts
@@ -1,7 +1,7 @@
 import type { IGraphQLConfig } from "graphql-config";
 
 const config: IGraphQLConfig = {
-  schema: "https://api.crm.refine.dev/graphql",
+  schema: "http://localhost:8000",
   extensions: {
     codegen: {
       hooks: {

--- a/frontend-graphql/app-crm/src/providers/data/index.ts
+++ b/frontend-graphql/app-crm/src/providers/data/index.ts
@@ -7,9 +7,9 @@ import { createClient } from "graphql-ws";
 
 import { axiosInstance } from "./axios";
 
-export const API_BASE_URL = "https://api.crm.refine.dev";
-export const API_URL = `${API_BASE_URL}/graphql`;
-export const WS_URL = "wss://api.crm.refine.dev/graphql";
+export const API_BASE_URL = "http://localhost:8000";
+export const API_URL = `${API_BASE_URL}`;
+export const WS_URL = "ws://localhost:8000/graphql";
 
 export const client = new GraphQLClient(API_URL, {
   fetch: async (url: string, options: any) => {

--- a/frontend-graphql/app-crm/src/providers/data/refresh-token.ts
+++ b/frontend-graphql/app-crm/src/providers/data/refresh-token.ts
@@ -27,7 +27,7 @@ export const refreshTokens = async () => {
 
   try {
     const response = await request<RefreshTokenMutation>(
-      "https://api.crm.refine.dev/graphql",
+      "http://localhost:8000",
       REFRESH_TOKEN_MUTATION,
       {
         refreshToken: currentRefreshToken,


### PR DESCRIPTION
## Summary
- update API endpoints for local backend
- point codegen and GraphQL config to local server

## Testing
- `npm test` *(fails: jest not found)*