### PR TITLE
Add event category list with count

### DIFF
--- a/graphql-typegraphql-crud-final/src/resolvers/EventCategoryResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/EventCategoryResolver.ts
@@ -1,15 +1,20 @@
 import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
 import { PrismaClient } from "@prisma/client";
 import { EventCategory } from "../schema/EventCategory";
+import { EventCategoryConnection } from "../schema/EventCategoryConnection";
 import { CreateEventCategoryInput, UpdateEventCategoryInput } from "../schema/EventCategoryInput";
 
 const prisma = new PrismaClient();
 
 @Resolver(() => EventCategory)
 export class EventCategoryResolver {
-  @Query(() => [EventCategory])
+  @Query(() => EventCategoryConnection)
   async eventCategories() {
-    return prisma.eventCategory.findMany();
+    const [nodes, totalCount] = await Promise.all([
+      prisma.eventCategory.findMany(),
+      prisma.eventCategory.count(),
+    ]);
+    return { nodes, totalCount };
   }
 
   @Query(() => EventCategory, { nullable: true })

--- a/graphql-typegraphql-crud-final/src/schema/EventCategoryConnection.ts
+++ b/graphql-typegraphql-crud-final/src/schema/EventCategoryConnection.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from "type-graphql";
+import { EventCategory } from "./EventCategory";
+
+@ObjectType()
+export class EventCategoryConnection {
+  @Field(() => [EventCategory])
+  nodes: EventCategory[];
+
+  @Field()
+  totalCount: number;
+}


### PR DESCRIPTION
## Summary
- add `EventCategoryConnection` schema object
- update `eventCategories` query to return node list and `totalCount`

## Testing
- `npx tsc --noEmit --skipLibCheck --project tsconfig.json` *(fails: File '../../prisma/seed.ts' is not under 'rootDir')*