### PR TITLE
Update Event detail with relations

### DIFF
--- a/graphql-typegraphql-crud-final/src/resolvers/EventResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/EventResolver.ts
@@ -14,7 +14,14 @@ export class EventResolver {
 
   @Query(() => Event, { nullable: true })
   async event(@Arg("id", () => ID) id: number) {
-    return prisma.event.findUnique({ where: { id } });
+    return prisma.event.findUnique({
+      where: { id },
+      include: {
+        createdBy: true,
+        category: true,
+        participants: true,
+      },
+    });
   }
 
   @Mutation(() => Event)

--- a/graphql-typegraphql-crud-final/src/schema/Event.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Event.ts
@@ -1,4 +1,6 @@
 import { Field, ID, ObjectType } from "type-graphql";
+import { User } from "./User";
+import { EventCategory } from "./EventCategory";
 
 @ObjectType()
 export class Event {
@@ -25,6 +27,15 @@ export class Event {
 
   @Field({ nullable: true })
   categoryId?: number;
+
+  @Field(() => User, { nullable: true })
+  createdBy?: User | null;
+
+  @Field(() => EventCategory, { nullable: true })
+  category?: EventCategory | null;
+
+  @Field(() => [User])
+  participants: User[];
 
   @Field()
   createdAt: Date;


### PR DESCRIPTION
## Summary
- expose related data on `Event` object
- include relations when fetching a single event

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: File 'prisma/seed.ts' is not under 'rootDir')*