### PR TITLE
Add total count for task stage query

### DIFF
--- a/graphql-typegraphql-crud-final/src/resolvers/TaskStageResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/TaskStageResolver.ts
@@ -1,15 +1,17 @@
 import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
 import { PrismaClient } from "@prisma/client";
-import { TaskStage } from "../schema/TaskStage";
+import { TaskStage, TaskStageConnection } from "../schema/TaskStage";
 import { CreateTaskStageInput, UpdateTaskStageInput } from "../schema/TaskStageInput";
 
 const prisma = new PrismaClient();
 
 @Resolver(() => TaskStage)
 export class TaskStageResolver {
-  @Query(() => [TaskStage])
+  @Query(() => TaskStageConnection)
   async taskStages() {
-    return prisma.taskStage.findMany();
+    const nodes = await prisma.taskStage.findMany();
+    const totalCount = await prisma.taskStage.count();
+    return { nodes, totalCount };
   }
 
   @Query(() => TaskStage, { nullable: true })

--- a/graphql-typegraphql-crud-final/src/schema/TaskStage.ts
+++ b/graphql-typegraphql-crud-final/src/schema/TaskStage.ts
@@ -20,3 +20,12 @@ export class TaskStage {
   @Field()
   updatedAt: Date;
 }
+
+@ObjectType()
+export class TaskStageConnection {
+  @Field(() => [TaskStage])
+  nodes: TaskStage[];
+
+  @Field()
+  totalCount: number;
+}

--- a/graphql-typegraphql-crud-final/tsconfig.json
+++ b/graphql-typegraphql-crud-final/tsconfig.json
@@ -6,8 +6,10 @@
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
+    "strictPropertyInitialization": false,
     "esModuleInterop": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true
-  }
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- expand `taskStages` query to return a `TaskStageConnection`
- include count in resolver logic
- relax TypeScript `strictPropertyInitialization` and add include path

## Testing
- `npx tsc -p tsconfig.json` *(fails: TypeScript errors in existing files)*