### PR TITLE
Add totalRevenue to company schema

### DIFF
--- a/graphql-typegraphql-crud-final/prisma/migrations/20250530000000_add_total_revenue/migration.sql
+++ b/graphql-typegraphql-crud-final/prisma/migrations/20250530000000_add_total_revenue/migration.sql
@@ -1,0 +1,2 @@
+-- Add totalRevenue column to Company
+ALTER TABLE "Company" ADD COLUMN "totalRevenue" INTEGER;

--- a/graphql-typegraphql-crud-final/prisma/schema.prisma
+++ b/graphql-typegraphql-crud-final/prisma/schema.prisma
@@ -40,6 +40,7 @@ model Company {
   description  String?
   avatarUrl    String?
   website      String?
+  totalRevenue Int?
   companySize  String?
   businessType String?
   address      String?

--- a/graphql-typegraphql-crud-final/prisma/seed.ts
+++ b/graphql-typegraphql-crud-final/prisma/seed.ts
@@ -16,11 +16,11 @@ async function main() {
   // Company
   await prisma.company.createMany({
     data: [
-      { name: "Acme Corp", industry: "Tech", description: "A tech company", avatarUrl: "https://example.com/acme.png", website: "https://acme.com", companySize: "100-500", businessType: "B2B", address: "123 Acme St", city: "New York", country: "USA", salesOwnerId: 1 },
-      { name: "Beta Ltd", industry: "Finance", description: "A finance company", avatarUrl: "https://example.com/beta.png", website: "https://beta.com", companySize: "50-100", businessType: "B2C", address: "456 Beta Ave", city: "London", country: "UK", salesOwnerId: 2 },
-      { name: "Gamma Inc", industry: "Health", description: "A health company", avatarUrl: "https://example.com/gamma.png", website: "https://gamma.com", companySize: "200-1000", businessType: "B2B", address: "789 Gamma Rd", city: "Berlin", country: "Germany", salesOwnerId: 3 },
-      { name: "Delta LLC", industry: "Retail", description: "A retail company", avatarUrl: "https://example.com/delta.png", website: "https://delta.com", companySize: "10-50", businessType: "B2C", address: "101 Delta Blvd", city: "Paris", country: "France", salesOwnerId: 4 },
-      { name: "Epsilon PLC", industry: "Education", description: "An education company", avatarUrl: "https://example.com/epsilon.png", website: "https://epsilon.com", companySize: "500-2000", businessType: "B2B", address: "202 Epsilon Sq", city: "Tokyo", country: "Japan", salesOwnerId: 5 },
+      { name: "Acme Corp", industry: "Tech", description: "A tech company", avatarUrl: "https://example.com/acme.png", website: "https://acme.com", totalRevenue: 100000, companySize: "100-500", businessType: "B2B", address: "123 Acme St", city: "New York", country: "USA", salesOwnerId: 1 },
+      { name: "Beta Ltd", industry: "Finance", description: "A finance company", avatarUrl: "https://example.com/beta.png", website: "https://beta.com", totalRevenue: 200000, companySize: "50-100", businessType: "B2C", address: "456 Beta Ave", city: "London", country: "UK", salesOwnerId: 2 },
+      { name: "Gamma Inc", industry: "Health", description: "A health company", avatarUrl: "https://example.com/gamma.png", website: "https://gamma.com", totalRevenue: 300000, companySize: "200-1000", businessType: "B2B", address: "789 Gamma Rd", city: "Berlin", country: "Germany", salesOwnerId: 3 },
+      { name: "Delta LLC", industry: "Retail", description: "A retail company", avatarUrl: "https://example.com/delta.png", website: "https://delta.com", totalRevenue: 400000, companySize: "10-50", businessType: "B2C", address: "101 Delta Blvd", city: "Paris", country: "France", salesOwnerId: 4 },
+      { name: "Epsilon PLC", industry: "Education", description: "An education company", avatarUrl: "https://example.com/epsilon.png", website: "https://epsilon.com", totalRevenue: 500000, companySize: "500-2000", businessType: "B2B", address: "202 Epsilon Sq", city: "Tokyo", country: "Japan", salesOwnerId: 5 },
     ],
   });
 

--- a/graphql-typegraphql-crud-final/src/schema/Company.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Company.ts
@@ -21,6 +21,9 @@ export class Company {
   website?: string;
 
   @Field({ nullable: true })
+  totalRevenue?: number;
+
+  @Field({ nullable: true })
   companySize?: string;
 
   @Field({ nullable: true })

--- a/graphql-typegraphql-crud-final/src/schema/CompanyInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/CompanyInput.ts
@@ -18,6 +18,9 @@ export class CreateCompanyInput {
   website?: string;
 
   @Field({ nullable: true })
+  totalRevenue?: number;
+
+  @Field({ nullable: true })
   companySize?: string;
 
   @Field({ nullable: true })
@@ -52,6 +55,9 @@ export class UpdateCompanyInput {
 
   @Field({ nullable: true })
   website?: string;
+
+  @Field({ nullable: true })
+  totalRevenue?: number;
 
   @Field({ nullable: true })
   companySize?: string;


### PR DESCRIPTION
## Summary
- support `totalRevenue` on `Company`
- seed example companies with initial revenue
- add database migration for the new column

## Testing
- `npx tsc --noEmit src/index.ts` *(fails: File '/workspace/.../prisma/seed.ts' is not under 'rootDir')*