### PR TITLE
Update contact fields and resolvers

### DIFF
--- a/graphql-typegraphql-crud-final/prisma/schema.prisma
+++ b/graphql-typegraphql-crud-final/prisma/schema.prisma
@@ -68,6 +68,7 @@ model Contact {
   company     Company? @relation("CompanyContacts", fields: [companyId], references: [id])
   status      String?
   jobTitle    String?
+  avatarUrl   String?
   deals       Deal[]    @relation("DealContact")
 
   salesOwnerId Int?

--- a/graphql-typegraphql-crud-final/prisma/seed.ts
+++ b/graphql-typegraphql-crud-final/prisma/seed.ts
@@ -27,11 +27,11 @@ async function main() {
   // Contact
   await prisma.contact.createMany({
     data: [
-      { name: "Contact 1", email: "c1@example.com", phone: "111-111-1111", description: "Main contact", companyId: 1, status: "active", jobTitle: "CEO", salesOwnerId: 1 },
-      { name: "Contact 2", email: "c2@example.com", phone: "222-222-2222", description: "Secondary contact", companyId: 2, status: "inactive", jobTitle: "CTO", salesOwnerId: 2 },
-      { name: "Contact 3", email: "c3@example.com", phone: "333-333-3333", description: "Support contact", companyId: 3, status: "active", jobTitle: "CFO", salesOwnerId: 3 },
-      { name: "Contact 4", email: "c4@example.com", phone: "444-444-4444", description: "Sales contact", companyId: 4, status: "active", jobTitle: "COO", salesOwnerId: 4 },
-      { name: "Contact 5", email: "c5@example.com", phone: "555-555-5555", description: "HR contact", companyId: 5, status: "inactive", jobTitle: "CMO", salesOwnerId: 5 },
+      { name: "Contact 1", email: "c1@example.com", phone: "111-111-1111", description: "Main contact", companyId: 1, status: "active", jobTitle: "CEO", avatarUrl: "https://example.com/contact1.png", salesOwnerId: 1 },
+      { name: "Contact 2", email: "c2@example.com", phone: "222-222-2222", description: "Secondary contact", companyId: 2, status: "inactive", jobTitle: "CTO", avatarUrl: "https://example.com/contact2.png", salesOwnerId: 2 },
+      { name: "Contact 3", email: "c3@example.com", phone: "333-333-3333", description: "Support contact", companyId: 3, status: "active", jobTitle: "CFO", avatarUrl: "https://example.com/contact3.png", salesOwnerId: 3 },
+      { name: "Contact 4", email: "c4@example.com", phone: "444-444-4444", description: "Sales contact", companyId: 4, status: "active", jobTitle: "COO", avatarUrl: "https://example.com/contact4.png", salesOwnerId: 4 },
+      { name: "Contact 5", email: "c5@example.com", phone: "555-555-5555", description: "HR contact", companyId: 5, status: "inactive", jobTitle: "CMO", avatarUrl: "https://example.com/contact5.png", salesOwnerId: 5 },
     ],
   });
 

--- a/graphql-typegraphql-crud-final/src/resolvers/ContactResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/ContactResolver.ts
@@ -9,17 +9,17 @@ const prisma = new PrismaClient();
 export class ContactResolver {
   @Query(() => [Contact])
   async contacts() {
-    return prisma.contact.findMany();
+    return prisma.contact.findMany({ include: { company: true } });
   }
 
   @Query(() => Contact, { nullable: true })
   async contact(@Arg("id", () => ID) id: number) {
-    return prisma.contact.findUnique({ where: { id } });
+    return prisma.contact.findUnique({ where: { id }, include: { company: true } });
   }
 
   @Mutation(() => Contact)
   async createContact(@Arg("data") data: CreateContactInput) {
-    return prisma.contact.create({ data });
+    return prisma.contact.create({ data, include: { company: true } });
   }
 
   @Mutation(() => Contact, { nullable: true })
@@ -30,7 +30,7 @@ export class ContactResolver {
     const updateData = Object.fromEntries(
       Object.entries(data).filter(([, value]) => value !== undefined)
     ) as UpdateContactInput;
-    return prisma.contact.update({ where: { id }, data: updateData });
+    return prisma.contact.update({ where: { id }, data: updateData, include: { company: true } });
   }
 
   @Mutation(() => Boolean)

--- a/graphql-typegraphql-crud-final/src/schema/Contact.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Contact.ts
@@ -1,4 +1,5 @@
 import { Field, ID, ObjectType } from "type-graphql";
+import { Company } from "./Company";
 
 @ObjectType()
 export class Contact {
@@ -25,6 +26,12 @@ export class Contact {
 
   @Field({ nullable: true })
   jobTitle?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field(() => Company, { nullable: true })
+  company?: Company;
 
   @Field({ nullable: true })
   salesOwnerId?: number;

--- a/graphql-typegraphql-crud-final/src/schema/ContactInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/ContactInput.ts
@@ -24,6 +24,9 @@ export class CreateContactInput {
   jobTitle?: string;
 
   @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field({ nullable: true })
   salesOwnerId?: number;
 }
 
@@ -49,6 +52,9 @@ export class UpdateContactInput {
 
   @Field({ nullable: true })
   jobTitle?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
 
   @Field({ nullable: true })
   salesOwnerId?: number;


### PR DESCRIPTION
## Summary
- support avatarUrl and company relation on Contact Prisma model
- expose avatarUrl and company in Contact GraphQL schema and input types
- include related company when resolving contacts
- seed contact avatars in database seed script

## Testing
- `npx prisma generate` *(fails: connect EHOSTUNREACH)*
- `npm test` *(fails: Missing script: "test")*