### PR TITLE
Add nested data to quote queries

### DIFF
--- a/graphql-typegraphql-crud-final/src/resolvers/QuoteResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/QuoteResolver.ts
@@ -9,12 +9,27 @@ const prisma = new PrismaClient();
 export class QuoteResolver {
   @Query(() => [Quote])
   async quotes() {
-    return prisma.quote.findMany();
+    return prisma.quote.findMany({
+      include: {
+        items: true,
+        company: true,
+        salesOwner: true,
+        contact: true,
+      },
+    });
   }
 
   @Query(() => Quote, { nullable: true })
   async quote(@Arg("id", () => ID) id: number) {
-    return prisma.quote.findUnique({ where: { id } });
+    return prisma.quote.findUnique({
+      where: { id },
+      include: {
+        items: true,
+        company: true,
+        salesOwner: true,
+        contact: true,
+      },
+    });
   }
 
   @Mutation(() => Quote)

--- a/graphql-typegraphql-crud-final/src/schema/Quote.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Quote.ts
@@ -1,4 +1,8 @@
 import { Field, ID, ObjectType } from "type-graphql";
+import { Product } from "./Product";
+import { Company } from "./Company";
+import { User } from "./User";
+import { Contact } from "./Contact";
 
 @ObjectType()
 export class Quote {
@@ -37,4 +41,16 @@ export class Quote {
 
   @Field({ nullable: true })
   contactId?: number;
+
+  @Field(() => [Product])
+  items?: Product[];
+
+  @Field(() => Company, { nullable: true })
+  company?: Company;
+
+  @Field(() => User, { nullable: true })
+  salesOwner?: User;
+
+  @Field(() => Contact, { nullable: true })
+  contact?: Contact;
 }


### PR DESCRIPTION
## Summary
- extend `Quote` schema with relations to items, company, salesOwner and contact
- include related entities when fetching quotes

## Testing
- `npm test` *(fails: Missing script)*