### PR TITLE
Add user relation in audit resolver

### DIFF
--- a/graphql-typegraphql-crud-final/src/resolvers/AuditResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/AuditResolver.ts
@@ -9,12 +9,12 @@ const prisma = new PrismaClient();
 export class AuditResolver {
   @Query(() => [Audit])
   async audits() {
-    return prisma.audit.findMany();
+    return prisma.audit.findMany({ include: { user: true } });
   }
 
   @Query(() => Audit, { nullable: true })
   async audit(@Arg("id", () => ID) id: number) {
-    return prisma.audit.findUnique({ where: { id } });
+    return prisma.audit.findUnique({ where: { id }, include: { user: true } });
   }
 
   @Mutation(() => Audit)

--- a/graphql-typegraphql-crud-final/src/schema/Audit.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Audit.ts
@@ -1,4 +1,5 @@
 import { Field, ID, ObjectType } from "type-graphql";
+import { User } from "./User";
 
 @ObjectType()
 export class Audit {
@@ -19,6 +20,9 @@ export class Audit {
 
   @Field({ nullable: true })
   userId?: number;
+
+  @Field(() => User, { nullable: true })
+  user?: User;
 
   @Field()
   createdAt: Date;


### PR DESCRIPTION
## Summary
- include `user` relation in `Audit` model
- fetch related `user` when listing audits

## Testing
- `npx tsc --noEmit src/index.ts src/resolvers/AuditResolver.ts src/schema/Audit.ts src/schema/User.ts` *(fails: Unable to resolve signature of property decorator when called as an expression)*