### PR TITLE
Add company pagination and relations

### DIFF
--- a/frontend-graphql/app-crm/README.md
+++ b/frontend-graphql/app-crm/README.md
@@ -69,6 +69,45 @@ refine is a React-based powerful framework for building low-code applications. I
 
 ![Product Edit Page](https://refine.ams3.cdn.digitaloceanspaces.com/example-readmes/login.png "Product Edit Page")
 
+## Company API Endpoints
+
+### 1. List Companies
+
+- **Endpoint:** `GET /companies`
+- **Returns:**
+  - `id`
+  - `name`
+  - `avatarUrl`
+  - `dealsAggregate.sum.value`
+  - `salesOwner` (user info)
+  - `contacts` (basic contact info)
+
+Example response:
+
+```json
+{
+  "data": {
+    "companies": {
+      "nodes": [
+        {
+          "id": 1,
+          "name": "Acme",
+          "avatarUrl": null,
+          "dealsAggregate": [
+            { "sum": { "value": 1000 } }
+          ],
+          "salesOwner": { "id": 2, "name": "Jane" },
+          "contacts": [
+            { "id": 5, "name": "John" }
+          ]
+        }
+      ],
+      "totalCount": 1
+    }
+  }
+}
+```
+
 ## Try this example on your local
 
 ```bash

--- a/graphql-typegraphql-crud-final/src/resolvers/CompanyResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/CompanyResolver.ts
@@ -1,15 +1,62 @@
 import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
 import { PrismaClient } from "@prisma/client";
 import { Company } from "../schema/Company";
+import { CompanyListResponse } from "../schema/CompanyListResponse";
+import { OffsetPaging } from "../schema/PagingInput";
+import { CompanyFilter } from "../schema/CompanyFilter";
+import { CompanySort } from "../schema/CompanySort";
 import { CreateCompanyInput, UpdateCompanyInput } from "../schema/CompanyInput";
 
 const prisma = new PrismaClient();
 
 @Resolver(() => Company)
 export class CompanyResolver {
-  @Query(() => [Company])
-  async companies() {
-    return prisma.company.findMany();
+  @Query(() => CompanyListResponse)
+  async companies(
+    @Arg("filter", () => CompanyFilter, { nullable: true }) filter: CompanyFilter,
+    @Arg("sorting", () => [CompanySort], { nullable: true }) sorting: CompanySort[],
+    @Arg("paging", () => OffsetPaging, { nullable: true }) paging: OffsetPaging
+  ): Promise<CompanyListResponse> {
+    const where: any = {};
+    if (filter?.name) {
+      where.name = { contains: filter.name };
+    }
+
+    const orderBy = sorting?.map((s) => ({ [s.field]: s.direction }));
+
+    const skip = paging?.offset ?? 0;
+    const take = paging?.limit ?? 10;
+
+    const [nodes, totalCount] = await prisma.$transaction([
+      prisma.company.findMany({
+        where,
+        orderBy,
+        skip,
+        take,
+        include: {
+          salesOwner: true,
+          contacts: true,
+        },
+      }),
+      prisma.company.count({ where }),
+    ]);
+
+    const nodesWithAggregate = await Promise.all(
+      nodes.map(async (company) => {
+        const sum = await prisma.deal.aggregate({
+          where: { companyId: company.id },
+          _sum: { amount: true },
+        });
+        return {
+          ...company,
+          dealsAggregate: [
+            { sum: { value: sum._sum.amount ?? 0 } },
+          ],
+        } as any;
+      })
+    );
+
+    return { nodes: nodesWithAggregate as any, totalCount };
   }
 
   @Query(() => Company, { nullable: true })

--- a/graphql-typegraphql-crud-final/src/schema/Company.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Company.ts
@@ -1,4 +1,18 @@
 import { Field, ID, ObjectType } from "type-graphql";
+import { Contact } from "./Contact";
+import { User } from "./User";
+
+@ObjectType()
+export class DealSum {
+  @Field()
+  value: number;
+}
+
+@ObjectType()
+export class DealAggregate {
+  @Field(() => DealSum)
+  sum: DealSum;
+}
 
 @ObjectType()
 export class Company {
@@ -37,6 +51,15 @@ export class Company {
 
   @Field({ nullable: true })
   salesOwnerId?: number;
+
+  @Field(() => User, { nullable: true })
+  salesOwner?: User | null;
+
+  @Field(() => [Contact])
+  contacts?: Contact[];
+
+  @Field(() => [DealAggregate], { nullable: true })
+  dealsAggregate?: DealAggregate[];
 
   @Field()
   createdAt: Date;

--- a/graphql-typegraphql-crud-final/src/schema/CompanyFilter.ts
+++ b/graphql-typegraphql-crud-final/src/schema/CompanyFilter.ts
@@ -1,0 +1,7 @@
+import { Field, InputType } from "type-graphql";
+
+@InputType()
+export class CompanyFilter {
+  @Field({ nullable: true })
+  name?: string;
+}

--- a/graphql-typegraphql-crud-final/src/schema/CompanyListResponse.ts
+++ b/graphql-typegraphql-crud-final/src/schema/CompanyListResponse.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from "type-graphql";
+import { Company } from "./Company";
+
+@ObjectType()
+export class CompanyListResponse {
+  @Field(() => [Company])
+  nodes: Company[];
+
+  @Field()
+  totalCount: number;
+}

--- a/graphql-typegraphql-crud-final/src/schema/CompanySort.ts
+++ b/graphql-typegraphql-crud-final/src/schema/CompanySort.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from "type-graphql";
+
+@InputType()
+export class CompanySort {
+  @Field()
+  field: string;
+
+  @Field()
+  direction: "asc" | "desc";
+}

--- a/graphql-typegraphql-crud-final/src/schema/Deal.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Deal.ts
@@ -11,6 +11,11 @@ export class Deal {
   @Field()
   amount: number;
 
+  @Field({ name: "value" })
+  getValue(): number {
+    return this.amount;
+  }
+
   @Field({ nullable: true })
   description?: string;
 

--- a/graphql-typegraphql-crud-final/src/schema/PagingInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/PagingInput.ts
@@ -1,0 +1,10 @@
+import { Field, InputType, Int } from "type-graphql";
+
+@InputType()
+export class OffsetPaging {
+  @Field(() => Int)
+  limit: number = 10;
+
+  @Field(() => Int)
+  offset: number = 0;
+}


### PR DESCRIPTION
## Summary
- extend Company GraphQL schema with relations and deal aggregate
- implement paginated `companies` query with filtering and sorting
- alias Deal amount as `value`
- document sample company list response

## Testing
- `npm test --silent` *(fails: no tests defined)*