### PR TITLE
Add nested data to quote queries

### DIFF
--- a/frontend-graphql/app-crm/src/routes/sales/quotes/show/index.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/quotes/show/index.tsx
@@ -41,43 +41,24 @@ export const QuotesShowPage = () => {
   if (isLoading || !data?.data) {
     return <FullScreenLoading />;
   }
-  const mockData={
-    id: "S00013",
-    title: "S00013",
-    createdAt: "2025-05-23",
-    company: { 
-      name: "Bouwsoft, Groensoft & Archisoft" ,
-      country: "Belgium",
-      website: "https://www.bouwsoft.be",
-      avatarUrl: "https://refine-crm.ams3.cdn.digitaloceanspaces.com/companies/11.png"
-    },
-    salesOwner: { name: "Administrator" },
-  
-    total: 20,
-    status: "ACCEPTED",
-   
-    contact: { name: "John Doe" },
-    expiration: "2025-05-23",
-    paymentTerm: "2025-05-23",
-    fiscalPosition: "2025-05-23",
-    analyticAccount: "2025-05-23",
-    tracking: {
-      sourceDocument: "2025-05-23",
-    },
-    projects:{
-      totalCount: 1,
-    },
-    tasks:{
-      totalCount: 1,
-    },
-    activities:{
-      totalCount: 1,
-    },
-    invoices:{
-      totalCount: 1,
-    }
-  }
-  const { title, id, status, company, contact, salesOwner, expiration, paymentTerm, fiscalPosition, analyticAccount, tracking,projects,tasks,activities,invoices } = mockData;
+
+  const {
+    title,
+    id,
+    status,
+    company,
+    contact,
+    salesOwner,
+    expiration,
+    paymentTerm,
+    fiscalPosition,
+    analyticAccount,
+    tracking,
+    projects,
+    tasks,
+    activities,
+    invoices,
+  } = (data.data as any);
 
   // Helper to safely get name or fallback to '_'
   const safeName = (obj: any) => obj?.name ?? '_';

--- a/graphql-typegraphql-crud-final/src/resolvers/QuoteResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/QuoteResolver.ts
@@ -9,12 +9,27 @@ const prisma = new PrismaClient();
 export class QuoteResolver {
   @Query(() => [Quote])
   async quotes() {
-    return prisma.quote.findMany();
+    return prisma.quote.findMany({
+      include: {
+        items: true,
+        company: true,
+        salesOwner: true,
+        contact: true,
+      },
+    });
   }
 
   @Query(() => Quote, { nullable: true })
   async quote(@Arg("id", () => ID) id: number) {
-    return prisma.quote.findUnique({ where: { id } });
+    return prisma.quote.findUnique({
+      where: { id },
+      include: {
+        items: true,
+        company: true,
+        salesOwner: true,
+        contact: true,
+      },
+    });
   }
 
   @Mutation(() => Quote)

--- a/graphql-typegraphql-crud-final/src/schema/Quote.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Quote.ts
@@ -1,4 +1,8 @@
 import { Field, ID, ObjectType } from "type-graphql";
+import { Product } from "./Product";
+import { Company } from "./Company";
+import { User } from "./User";
+import { Contact } from "./Contact";
 
 @ObjectType()
 export class Quote {
@@ -37,4 +41,16 @@ export class Quote {
 
   @Field({ nullable: true })
   contactId?: number;
+
+  @Field(() => [Product])
+  items?: Product[];
+
+  @Field(() => Company, { nullable: true })
+  company?: Company;
+
+  @Field(() => User, { nullable: true })
+  salesOwner?: User;
+
+  @Field(() => Contact, { nullable: true })
+  contact?: Contact;
 }


### PR DESCRIPTION
## Summary
- extend `Quote` schema with relations to items, company, salesOwner and contact
- include related entities when fetching quotes
- show real quote data instead of mock data in the quote details page

## Testing
- `npm test` *(fails: missing `package.json` at repo root)*
- `cd graphql-typegraphql-crud-final && npm test` *(fails: Missing script)*
- `cd frontend-graphql/app-crm && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839664176188322ac3a3172f114a867