### PR TITLE
Update event category API docs

### DIFF
--- a/frontend-graphql/app-crm/README.md
+++ b/frontend-graphql/app-crm/README.md
@@ -142,3 +142,27 @@ Returns the following fields for each quote:
 - `salesOwner`
 - `contact`
 
+### List Event Categories
+
+**Endpoint:** `GET /eventCategories`
+
+Returns the following fields for each event category:
+
+- `id`
+- `title`
+
+Example response:
+
+```json
+{
+  "data": {
+    "eventCategories": {
+      "nodes": [
+        { "id": 1, "title": "EventCat 1" }
+      ],
+      "totalCount": 5
+    }
+  }
+}
+```
+

--- a/graphql-typegraphql-crud-final/src/resolvers/EventCategoryResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/EventCategoryResolver.ts
@@ -5,6 +5,10 @@ import { EventCategoryListResponse } from "../schema/EventCategoryListResponse";
 import { EventCategoryFilter } from "../schema/EventCategoryFilter";
 import { EventCategorySort } from "../schema/EventCategorySort";
 import { OffsetPaging } from "../schema/PagingInput";
+import {
+  CreateEventCategoryInput,
+  UpdateEventCategoryInput,
+} from "../schema/EventCategoryInput";
 
 const prisma = new PrismaClient();
 
@@ -47,20 +51,24 @@ export class EventCategoryResolver {
   }
 
   @Mutation(() => EventCategory)
-  async createEventCategory(@Arg("title") title: string) {
-    return prisma.eventCategory.create({
-      data: { title },
-    });
+  async createEventCategory(
+    @Arg("data") data: CreateEventCategoryInput,
+  ): Promise<EventCategory> {
+    return prisma.eventCategory.create({ data });
   }
 
   @Mutation(() => EventCategory, { nullable: true })
   async updateEventCategory(
     @Arg("id", () => ID) id: number,
-    @Arg("title") title: string
-  ) {
+    @Arg("data") data: UpdateEventCategoryInput,
+  ): Promise<EventCategory | null> {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined),
+    ) as UpdateEventCategoryInput;
+
     return prisma.eventCategory.update({
       where: { id },
-      data: { title },
+      data: updateData,
     });
   }
 


### PR DESCRIPTION
## Summary
- document event category API endpoint
- use input types for creating and updating event categories

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683aca844f7883229bb0713b0fd6ccf7