### PR TITLE
Align company module with event-style GraphQL inputs

### DIFF
--- a/frontend-graphql/app-crm/README.md
+++ b/frontend-graphql/app-crm/README.md
@@ -108,6 +108,38 @@ Example response:
   }
 }
 
+### 2. Create Company
+
+Companies are created via GraphQL using the `createCompany` mutation.
+
+```graphql
+mutation CreateCompany($input: CreateCompanyInput!) {
+  createCompany(input: $input) {
+    id
+    name
+    salesOwner {
+      id
+      name
+      avatarUrl
+    }
+  }
+}
+```
+
+Example variables:
+
+```json
+{
+  "input": {
+    "company": {
+      "name": "Acme",
+      "salesOwnerId": 1,
+      "website": "https://acme.com"
+    }
+  }
+}
+```
+
 
 ## Try this example on your local
 

--- a/frontend-graphql/app-crm/src/routes/companies/create.tsx
+++ b/frontend-graphql/app-crm/src/routes/companies/create.tsx
@@ -30,21 +30,18 @@ import {
 } from "antd";
 
 import { SelectOptionWithAvatar } from "@/components";
-import type {
-  CreateCompanyMutation,
-  CreateCompanyMutationVariables,
-} from "@/graphql/types";
+import type { CompanyCreateInput, Company } from "@/graphql/schema.types";
 import { useUsersSelect } from "@/hooks/useUsersSelect";
 
 import { COMPANY_CREATE_MUTATION } from "./queries";
 
-type Company = GetFields<CreateCompanyMutation>;
+type CompanyType = Company;
 
 type Props = {
   isOverModal?: boolean;
 };
 
-type FormValues = GetVariables<CreateCompanyMutationVariables> & {
+type FormValues = CompanyCreateInput & {
   contacts?: {
     name?: string;
     email?: string;
@@ -58,7 +55,7 @@ export const CompanyCreatePage = ({ isOverModal }: Props) => {
   const go = useGo();
 
   const { formProps, modalProps, close, onFinish } = useModalForm<
-    Company,
+    CompanyType,
     HttpError,
     FormValues
   >({
@@ -113,8 +110,12 @@ export const CompanyCreatePage = ({ isOverModal }: Props) => {
         onFinish={async (values) => {
           try {
             const data = await onFinish({
-              name: values.name,
-              salesOwnerId: values.salesOwnerId,
+              input: {
+                company: {
+                  name: values.name,
+                  salesOwnerId: values.salesOwnerId,
+                },
+              },
             });
 
             const createdCompany = (data as CreateResponse<Company>)?.data;

--- a/graphql-typegraphql-crud-final/src/resolvers/CompanyResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/CompanyResolver.ts
@@ -5,7 +5,7 @@ import { CompanyListResponse } from "../schema/CompanyListResponse";
 import { OffsetPaging } from "../schema/PagingInput";
 import { CompanyFilter } from "../schema/CompanyFilter";
 import { CompanySort } from "../schema/CompanySort";
-import { CreateCompanyInput, UpdateCompanyInput } from "../schema/CompanyInput";
+import { CompanyInput, CreateCompanyInput, UpdateCompanyInput } from "../schema/CompanyInput";
 
 const prisma = new PrismaClient();
 
@@ -105,19 +105,18 @@ export class CompanyResolver {
   }
 
   @Mutation(() => Company)
-  async createCompany(@Arg("data") data: CreateCompanyInput) {
-    return prisma.company.create({ data });
+  async createCompany(@Arg("input", () => CreateCompanyInput) input: CreateCompanyInput) {
+    return prisma.company.create({ data: input.company });
   }
 
   @Mutation(() => Company, { nullable: true })
   async updateCompany(
-    @Arg("id", () => ID) id: number,
-    @Arg("data") data: UpdateCompanyInput
+    @Arg("input", () => UpdateCompanyInput) input: UpdateCompanyInput
   ) {
     const updateData = Object.fromEntries(
-      Object.entries(data).filter(([, value]) => value !== undefined)
-    ) as UpdateCompanyInput;
-    return prisma.company.update({ where: { id }, data: updateData });
+      Object.entries(input.update).filter(([, value]) => value !== undefined)
+    ) as CompanyInput;
+    return prisma.company.update({ where: { id: input.id }, data: updateData });
   }
 
   @Mutation(() => Boolean)

--- a/graphql-typegraphql-crud-final/src/schema/CompanyInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/CompanyInput.ts
@@ -1,7 +1,7 @@
-import { InputType, Field } from "type-graphql";
+import { InputType, Field, ID } from "type-graphql";
 
 @InputType()
-export class CreateCompanyInput {
+export class CompanyInput {
   @Field()
   name: string;
 
@@ -40,40 +40,16 @@ export class CreateCompanyInput {
 }
 
 @InputType()
+export class CreateCompanyInput {
+  @Field(() => CompanyInput)
+  company: CompanyInput;
+}
+
+@InputType()
 export class UpdateCompanyInput {
-  @Field({ nullable: true })
-  name?: string;
+  @Field(() => ID)
+  id: number;
 
-  @Field({ nullable: true })
-  industry?: string;
-
-  @Field({ nullable: true })
-  description?: string;
-
-  @Field({ nullable: true })
-  avatarUrl?: string;
-
-  @Field({ nullable: true })
-  website?: string;
-
-  @Field({ nullable: true })
-  totalRevenue?: number;
-
-  @Field({ nullable: true })
-  companySize?: string;
-
-  @Field({ nullable: true })
-  businessType?: string;
-
-  @Field({ nullable: true })
-  address?: string;
-
-  @Field({ nullable: true })
-  city?: string;
-
-  @Field({ nullable: true })
-  country?: string;
-
-  @Field({ nullable: true })
-  salesOwnerId?: number;
+  @Field(() => CompanyInput)
+  update: CompanyInput;
 }


### PR DESCRIPTION
## Summary
- refactor `CompanyInput` to mirror `EventInput` structure
- update `CompanyResolver` to accept `CreateCompanyInput` and `UpdateCompanyInput`
- change company create mutation and form to send nested `company` data
- document `createCompany` usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e766e9a948322af09b9c694d02dc3