### PR TITLE
Add basic payroll GraphQL server

### DIFF
--- a/graphql-server/data/mockDb.ts
+++ b/graphql-server/data/mockDb.ts
@@ -1,0 +1,11 @@
+import { Employee, Payslip } from '../schema/types';
+
+export const employees: Employee[] = [
+  { id: '1', name: 'Alice Smith', position: 'Developer' },
+  { id: '2', name: 'Bob Johnson', position: 'Designer' },
+];
+
+export const payslips: Payslip[] = [
+  { id: '1', employeeId: '1', amount: 3000, date: '2024-06-01' },
+  { id: '2', employeeId: '2', amount: 2500, date: '2024-06-01' },
+];

--- a/graphql-server/index.ts
+++ b/graphql-server/index.ts
@@ -1,0 +1,13 @@
+import { ApolloServer } from 'apollo-server';
+import { typeDefs } from './schema/typeDefs';
+import { resolvers } from './schema/resolvers';
+
+async function startServer() {
+  const server = new ApolloServer({ typeDefs, resolvers });
+  const { url } = await server.listen({ port: 4000 });
+  console.log(`🚀 Payroll GraphQL server ready at ${url}`);
+}
+
+startServer().catch((err) => {
+  console.error('Failed to start server', err);
+});

--- a/graphql-server/models/employee.model.ts
+++ b/graphql-server/models/employee.model.ts
@@ -1,0 +1,5 @@
+export interface EmployeeModel {
+  id: string;
+  name: string;
+  position?: string;
+}

--- a/graphql-server/models/payslip.model.ts
+++ b/graphql-server/models/payslip.model.ts
@@ -1,0 +1,6 @@
+export interface PayslipModel {
+  id: string;
+  employeeId: string;
+  amount: number;
+  date: string;
+}

--- a/graphql-server/package.json
+++ b/graphql-server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "graphql-payroll-server",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "license": "MIT",
+  "scripts": {
+    "start": "ts-node index.ts"
+  },
+  "dependencies": {
+    "apollo-server": "^3.12.0",
+    "graphql": "^16.8.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4"
+  }
+}

--- a/graphql-server/schema/resolvers.ts
+++ b/graphql-server/schema/resolvers.ts
@@ -1,0 +1,10 @@
+import { employees, payslips } from '../data/mockDb';
+import { Resolvers } from './types';
+
+export const resolvers: Resolvers = {
+  Query: {
+    employees: () => employees,
+    employee: (_parent, args) => employees.find((e) => e.id === args.id) || null,
+    payslips: (_parent, args) => payslips.filter((p) => p.employeeId === args.employeeId),
+  },
+};

--- a/graphql-server/schema/typeDefs.ts
+++ b/graphql-server/schema/typeDefs.ts
@@ -1,0 +1,22 @@
+import { gql } from 'apollo-server';
+
+export const typeDefs = gql`
+  type Employee {
+    id: ID!
+    name: String!
+    position: String
+  }
+
+  type Payslip {
+    id: ID!
+    employeeId: ID!
+    amount: Float!
+    date: String!
+  }
+
+  type Query {
+    employees: [Employee!]!
+    employee(id: ID!): Employee
+    payslips(employeeId: ID!): [Payslip!]!
+  }
+`;

--- a/graphql-server/schema/types.ts
+++ b/graphql-server/schema/types.ts
@@ -1,0 +1,26 @@
+export interface Employee {
+  id: string;
+  name: string;
+  position?: string;
+}
+
+export interface Payslip {
+  id: string;
+  employeeId: string;
+  amount: number;
+  date: string;
+}
+
+export interface Query {
+  employees: Employee[];
+  employee?: Employee | null;
+  payslips: Payslip[];
+}
+
+export interface Resolvers {
+  Query: {
+    employees: () => Employee[];
+    employee: (_parent: unknown, args: { id: string }) => Employee | null;
+    payslips: (_parent: unknown, args: { employeeId: string }) => Payslip[];
+  };
+}

--- a/graphql-server/tsconfig.json
+++ b/graphql-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/graphql-server/utils/helpers.ts
+++ b/graphql-server/utils/helpers.ts
@@ -1,0 +1,3 @@
+export function formatCurrency(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}


### PR DESCRIPTION
## Summary
- scaffold `graphql-server` project for payroll example
- define GraphQL schema, resolvers and types
- add a small mock database
- include simple utility helpers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ab3e71f448322b50c67db56ce504e