### PR TITLE
Add payroll module

### DIFF
--- a/frontend-graphql/app-crm/src/graphql/payroll/fragments.graphql
+++ b/frontend-graphql/app-crm/src/graphql/payroll/fragments.graphql
@@ -1,0 +1,10 @@
+fragment PayrollFields on Payroll {
+  id
+  employeeId
+  workedHours
+  periodStart
+  periodEnd
+  approvedBy
+  createdAt
+  updatedAt
+}

--- a/frontend-graphql/app-crm/src/graphql/payroll/mutations.graphql
+++ b/frontend-graphql/app-crm/src/graphql/payroll/mutations.graphql
@@ -1,0 +1,16 @@
+mutation CreatePayroll($data: CreatePayrollInput!) {
+  createPayroll(data: $data) {
+    ...PayrollFields
+  }
+}
+
+mutation UpdatePayroll($id: ID!, $data: UpdatePayrollInput!) {
+  updatePayroll(id: $id, data: $data) {
+    ...PayrollFields
+  }
+}
+
+mutation DeletePayroll($id: ID!) {
+  deletePayroll(id: $id)
+}
+

--- a/frontend-graphql/app-crm/src/graphql/payroll/queries.graphql
+++ b/frontend-graphql/app-crm/src/graphql/payroll/queries.graphql
@@ -1,0 +1,12 @@
+query Payrolls {
+  payrolls {
+    ...PayrollFields
+  }
+}
+
+query Payroll($id: ID!) {
+  payroll(id: $id) {
+    ...PayrollFields
+  }
+}
+

--- a/graphql-typegraphql-crud-final/prisma/migrations/20250612000000_add_payroll/migration.sql
+++ b/graphql-typegraphql-crud-final/prisma/migrations/20250612000000_add_payroll/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "Payroll" (
+  "id" TEXT NOT NULL DEFAULT concat('c', substr(md5(random()::text), 1, 24)),
+  "employeeId" TEXT NOT NULL,
+  "workedHours" DOUBLE PRECISION NOT NULL,
+  "periodStart" TIMESTAMP(3) NOT NULL,
+  "periodEnd" TIMESTAMP(3) NOT NULL,
+  "approvedBy" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "Payroll_pkey" PRIMARY KEY ("id")
+);

--- a/graphql-typegraphql-crud-final/prisma/schema.prisma
+++ b/graphql-typegraphql-crud-final/prisma/schema.prisma
@@ -322,3 +322,14 @@ model Todo {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }
+
+model Payroll {
+  id          String   @id @default(cuid())
+  employeeId  String
+  workedHours Float
+  periodStart DateTime
+  periodEnd   DateTime
+  approvedBy  String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/graphql-typegraphql-crud-final/src/index.ts
+++ b/graphql-typegraphql-crud-final/src/index.ts
@@ -25,6 +25,7 @@ import { ProjectResolver } from "./resolvers/ProjectResolver";
 import { EventResolver } from "./resolvers/EventResolver";
 import { CommentResolver } from "./resolvers/CommentResolver";
 import { DashboardResolver } from "./resolvers/DashboardResolver";
+import { PayrollResolver } from "./resolvers/PayrollResolver";
 
 const prisma = new PrismaClient();
 
@@ -52,6 +53,7 @@ async function bootstrap() {
       ProjectResolver,
       EventResolver,
       CommentResolver,
+      PayrollResolver,
     ],
     validate: false,
   });

--- a/graphql-typegraphql-crud-final/src/resolvers/PayrollResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/PayrollResolver.ts
@@ -1,0 +1,41 @@
+import { Arg, ID, Mutation, Query, Resolver } from "type-graphql";
+import { PrismaClient } from "@prisma/client";
+import { Payroll } from "../schema/Payroll";
+import { CreatePayrollInput, UpdatePayrollInput } from "../schema/PayrollInput";
+
+const prisma = new PrismaClient();
+
+@Resolver(() => Payroll)
+export class PayrollResolver {
+  @Query(() => [Payroll])
+  async payrolls() {
+    return prisma.payroll.findMany();
+  }
+
+  @Query(() => Payroll, { nullable: true })
+  async payroll(@Arg("id", () => ID) id: string) {
+    return prisma.payroll.findUnique({ where: { id } });
+  }
+
+  @Mutation(() => Payroll)
+  async createPayroll(@Arg("data") data: CreatePayrollInput) {
+    return prisma.payroll.create({ data });
+  }
+
+  @Mutation(() => Payroll, { nullable: true })
+  async updatePayroll(
+    @Arg("id", () => ID) id: string,
+    @Arg("data") data: UpdatePayrollInput
+  ) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    ) as UpdatePayrollInput;
+    return prisma.payroll.update({ where: { id }, data: updateData });
+  }
+
+  @Mutation(() => Boolean)
+  async deletePayroll(@Arg("id", () => ID) id: string) {
+    await prisma.payroll.delete({ where: { id } });
+    return true;
+  }
+}

--- a/graphql-typegraphql-crud-final/src/schema/Payroll.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Payroll.ts
@@ -1,0 +1,28 @@
+import { Field, ID, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class Payroll {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  employeeId: string;
+
+  @Field()
+  workedHours: number;
+
+  @Field()
+  periodStart: Date;
+
+  @Field()
+  periodEnd: Date;
+
+  @Field({ nullable: true })
+  approvedBy?: string;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}

--- a/graphql-typegraphql-crud-final/src/schema/PayrollInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/PayrollInput.ts
@@ -1,0 +1,37 @@
+import { Field, InputType } from "type-graphql";
+
+@InputType()
+export class CreatePayrollInput {
+  @Field()
+  employeeId: string;
+
+  @Field()
+  workedHours: number;
+
+  @Field()
+  periodStart: Date;
+
+  @Field()
+  periodEnd: Date;
+
+  @Field({ nullable: true })
+  approvedBy?: string;
+}
+
+@InputType()
+export class UpdatePayrollInput {
+  @Field({ nullable: true })
+  employeeId?: string;
+
+  @Field({ nullable: true })
+  workedHours?: number;
+
+  @Field({ nullable: true })
+  periodStart?: Date;
+
+  @Field({ nullable: true })
+  periodEnd?: Date;
+
+  @Field({ nullable: true })
+  approvedBy?: string;
+}


### PR DESCRIPTION
## Summary
- add graphql queries/mutations/fragments for payroll to frontend
- support payroll in backend schema and resolvers
- add prisma migration for payroll model
- register Payroll resolver
- change payroll fields to match approved schema

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in backend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bf018bf68832288b71a36eab160c1