### PR TITLE
Add access control provider for payroll menu

### DIFF
--- a/frontend-graphql/app-crm/src/App.tsx
+++ b/frontend-graphql/app-crm/src/App.tsx
@@ -13,7 +13,12 @@ import routerProvider, {
 import { App as AntdApp, ConfigProvider } from "antd";
 
 import { resources, themeConfig } from "@/config";
-import { authProvider, dataProvider, liveProvider } from "@/providers";
+import {
+  authProvider,
+  dataProvider,
+  liveProvider,
+  accessControlProvider,
+} from "@/providers";
 
 import { AlgoliaSearchWrapper, FullScreenLoading, Layout } from "./components";
 import { useAutoLoginForDemo } from "./hooks";
@@ -90,6 +95,7 @@ const App: React.FC = () => {
                 liveProvider={liveProvider}
                 routerProvider={routerProvider}
                 resources={resources}
+                accessControlProvider={accessControlProvider}
                 notificationProvider={useNotificationProvider}
                 options={{
                   liveMode: "auto",

--- a/frontend-graphql/app-crm/src/providers/auth.ts
+++ b/frontend-graphql/app-crm/src/providers/auth.ts
@@ -201,3 +201,17 @@ export const authProvider: AuthProvider = {
     }
   },
 };
+
+import type { AccessControlProvider } from "@refinedev/core";
+
+export const accessControlProvider: AccessControlProvider = {
+  can: async ({ resource, action }) => {
+    if (resource === "payroll" && action === "list") {
+      return { can: true }; // ✅ explicitly allow access to payroll menu
+    }
+
+    // Optional: allow everything else
+    return { can: true };
+  },
+};
+


### PR DESCRIPTION
## Summary
- add `accessControlProvider` to allow payroll menu access
- provide provider to Refine in `App`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d3c1553588322941af79536e78743