### PR TITLE
Implement full product creation

### DIFF
--- a/USER_API_ENDPOINTS.md
+++ b/USER_API_ENDPOINTS.md
@@ -48,9 +48,7 @@ The endpoint responds with a JSON array of users with the fields listed above.
 
 - **Endpoint**: `POST /products`
 
-- **Body**: `title`, `description`, `unitPrice`, `status`, `categoryId`
-
-- **Body**: `title`, `description`, `unitPrice`, `categoryId`
+- **Body**: `name`, `internalReference`, `responsible`, `productTags`, `salesPrice`, `cost`, `quantityOnHand`, `forecastedQuantity`, `unitOfMeasure`, `status`, `description`, `categoryId`
 
 - **Returns**: the created product object.
 

--- a/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
@@ -90,9 +90,14 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
           try {
             await mutateAsync({
               values: {
-                title: values.name,
+                name: values.name,
+                internalReference: values.internalReference,
+                responsible: values.responsible,
+                productTags: values.tags || [],
                 description: values.description,
-                unitPrice: Number(values.salesPrice || 0),
+                salesPrice: Number(values.salesPrice || 0),
+                cost: Number(values.cost || 0),
+                unitOfMeasure: values.unitOfMeasure,
               },
             });
             onMutationSuccess?.();

--- a/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
+++ b/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
@@ -27,9 +27,16 @@ export const PRODUCT_CREATE_MUTATION = gql`
   mutation CreateProduct($data: CreateProductInput!) {
     createProduct(data: $data) {
       id
-      title
+      name
       description
-      unitPrice
+      internalReference
+      responsible
+      productTags
+      salesPrice
+      cost
+      quantityOnHand
+      forecastedQuantity
+      unitOfMeasure
       status
       categoryId
     }

--- a/graphql-typegraphql-crud-final/prisma/schema.prisma
+++ b/graphql-typegraphql-crud-final/prisma/schema.prisma
@@ -158,16 +158,23 @@ model Category {
 }
 
 model Product {
-  id          Int      @id @default(autoincrement())
-  title        String
-  description String?
-  unitPrice   Float
-  status      String   @default("AVAILABLE")
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  categoryId  Int?
-  category    Category? @relation("ProductCategory", fields: [categoryId], references: [id])
-  quotes      QuoteProduct[] @relation("QuoteProducts")
+  id                 Int      @id @default(autoincrement())
+  name               String
+  description        String?
+  internalReference  String?
+  responsible        String?
+  productTags        Json     @default(Json("[]"))
+  salesPrice         Float
+  cost               Float    @default(0)
+  quantityOnHand     Int      @default(0)
+  forecastedQuantity Int      @default(0)
+  unitOfMeasure      String   @default("Units")
+  status             String   @default("active")
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+  categoryId         Int?
+  category           Category?   @relation("ProductCategory", fields: [categoryId], references: [id])
+  quotes             QuoteProduct[] @relation("QuoteProducts")
 }
 
 model Quote {

--- a/graphql-typegraphql-crud-final/src/resolvers/ProductResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/ProductResolver.ts
@@ -19,7 +19,10 @@ export class ProductResolver {
 
   @Mutation(() => Product)
   async createProduct(@Arg("data") data: CreateProductInput) {
-    return prisma.product.create({ data });
+    const createData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined)
+    );
+    return prisma.product.create({ data: createData as any });
   }
 
   @Mutation(() => Product, { nullable: true })
@@ -29,8 +32,8 @@ export class ProductResolver {
   ) {
     const updateData = Object.fromEntries(
       Object.entries(data).filter(([, value]) => value !== undefined)
-    ) as UpdateProductInput;
-    return prisma.product.update({ where: { id }, data: updateData });
+    );
+    return prisma.product.update({ where: { id }, data: updateData as any });
   }
 
   @Mutation(() => Boolean)

--- a/graphql-typegraphql-crud-final/src/resolvers/QuoteFieldResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/QuoteFieldResolver.ts
@@ -11,7 +11,7 @@ export class QuoteFieldResolver {
     }
     
     return quote.items.reduce((total, item) => {
-      return total + (item.quantity * item.product.unitPrice);
+      return total + item.quantity * item.product.salesPrice;
     }, 0);
   }
 

--- a/graphql-typegraphql-crud-final/src/schema/Product.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Product.ts
@@ -1,4 +1,4 @@
-import { Field, ID, ObjectType } from "type-graphql";
+import { Field, ID, ObjectType, Int, Float } from "type-graphql";
 
 @ObjectType()
 export class Product {
@@ -6,13 +6,34 @@ export class Product {
   id: number;
 
   @Field()
-  title: string;
+  name: string;
 
   @Field({ nullable: true })
   description?: string;
 
+  @Field({ nullable: true })
+  internalReference?: string;
+
+  @Field({ nullable: true })
+  responsible?: string;
+
+  @Field(() => [String])
+  productTags: string[];
+
+  @Field(() => Float)
+  salesPrice: number;
+
+  @Field(() => Float)
+  cost: number;
+
+  @Field(() => Int)
+  quantityOnHand: number;
+
+  @Field(() => Int)
+  forecastedQuantity: number;
+
   @Field()
-  unitPrice: number;
+  unitOfMeasure: string;
 
   @Field({ nullable: true })
   status?: string;

--- a/graphql-typegraphql-crud-final/src/schema/ProductInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/ProductInput.ts
@@ -1,15 +1,36 @@
-import { Field, InputType } from "type-graphql";
+import { Field, InputType, Int, Float } from "type-graphql";
 
 @InputType()
 export class CreateProductInput {
   @Field()
-  title: string;
+  name: string;
+
+  @Field()
+  internalReference: string;
+
+  @Field()
+  responsible: string;
+
+  @Field(() => [String], { nullable: true })
+  productTags?: string[];
 
   @Field({ nullable: true })
   description?: string;
 
+  @Field(() => Float)
+  salesPrice: number;
+
+  @Field(() => Float, { nullable: true })
+  cost?: number;
+
+  @Field(() => Int, { nullable: true })
+  quantityOnHand?: number;
+
+  @Field(() => Int, { nullable: true })
+  forecastedQuantity?: number;
+
   @Field()
-  unitPrice: number;
+  unitOfMeasure: string;
 
   @Field({ nullable: true })
   status?: string;
@@ -21,13 +42,34 @@ export class CreateProductInput {
 @InputType()
 export class UpdateProductInput {
   @Field({ nullable: true })
-  title?: string;
+  name?: string;
+
+  @Field({ nullable: true })
+  internalReference?: string;
+
+  @Field({ nullable: true })
+  responsible?: string;
+
+  @Field(() => [String], { nullable: true })
+  productTags?: string[];
 
   @Field({ nullable: true })
   description?: string;
 
+  @Field(() => Float, { nullable: true })
+  salesPrice?: number;
+
+  @Field(() => Float, { nullable: true })
+  cost?: number;
+
+  @Field(() => Int, { nullable: true })
+  quantityOnHand?: number;
+
+  @Field(() => Int, { nullable: true })
+  forecastedQuantity?: number;
+
   @Field({ nullable: true })
-  unitPrice?: number;
+  unitOfMeasure?: string;
 
   @Field({ nullable: true })
   status?: string;


### PR DESCRIPTION
## Summary
- expand Product model to cover more fields
- extend GraphQL Product type and inputs
- update resolvers to handle new fields
- adjust queries and mutation call in the frontend
- update API docs for product creation

## Testing
- `npx tsc -p tsconfig.json --noEmit` in `graphql-typegraphql-crud-final`
- `npx tsc -p tsconfig.json --noEmit` in `frontend-graphql/app-crm` *(fails: Cannot find module 'dayjs')*


------
https://chatgpt.com/codex/tasks/task_e_685f7250642083318ea1b51ae515ac3b