### PR TITLE
Fix GraphQL error handling

### DIFF
--- a/frontend-graphql/app-crm/src/providers/data/index.ts
+++ b/frontend-graphql/app-crm/src/providers/data/index.ts
@@ -22,11 +22,22 @@ export const client = new GraphQLClient(API_URL, {
 
       return response;
     } catch (error: any) {
-      const messages = error?.map((error: any) => error?.message)?.join("");
-      const code = error?.[0]?.extensions?.code;
+      let graphQLErrors: any[] = [];
+
+      if (Array.isArray(error)) {
+        graphQLErrors = error;
+      } else if (Array.isArray(error?.response?.data?.errors)) {
+        graphQLErrors = error.response.data.errors;
+      }
+
+      const messages = graphQLErrors
+        .map((err: any) => err?.message)
+        .join("; ");
+      const code =
+        graphQLErrors[0]?.extensions?.code || error?.response?.status;
 
       return Promise.reject({
-        message: messages || JSON.stringify(error),
+        message: messages || error?.message || JSON.stringify(error),
         statusCode: code || 500,
       });
     }


### PR DESCRIPTION
## Summary
- improve error handling when submitting the product form
- guard against non-array errors in the GraphQL client

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f901dbd548331a3a5d55a784685f0