### PR TITLE
Fix GraphQL product fields

### DIFF
--- a/frontend-graphql/app-crm/src/providers/data/index.ts
+++ b/frontend-graphql/app-crm/src/providers/data/index.ts
@@ -22,11 +22,22 @@ export const client = new GraphQLClient(API_URL, {
 
       return response;
     } catch (error: any) {
-      const messages = error?.map((error: any) => error?.message)?.join("");
-      const code = error?.[0]?.extensions?.code;
+      let graphQLErrors: any[] = [];
+
+      if (Array.isArray(error)) {
+        graphQLErrors = error;
+      } else if (Array.isArray(error?.response?.data?.errors)) {
+        graphQLErrors = error.response.data.errors;
+      }
+
+      const messages = graphQLErrors
+        .map((err: any) => err?.message)
+        .join("; ");
+      const code =
+        graphQLErrors[0]?.extensions?.code || error?.response?.status;
 
       return Promise.reject({
-        message: messages || JSON.stringify(error),
+        message: messages || error?.message || JSON.stringify(error),
         statusCode: code || 500,
       });
     }

--- a/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
@@ -1,6 +1,18 @@
 import type { FC } from "react";
 import { useState } from "react";
-import { Modal, Form, Input, InputNumber, Select, Spin, Checkbox, Row, Col, Tabs } from "antd";
+import {
+  Modal,
+  Form,
+  Input,
+  InputNumber,
+  Select,
+  Spin,
+  Checkbox,
+  Row,
+  Col,
+  Tabs,
+  message,
+} from "antd";
 import { useNavigate } from "react-router-dom";
 import { type HttpError, useCreate } from "@refinedev/core";
 import styles from "./index.module.css";
@@ -58,7 +70,11 @@ type Props = {
   onMutationSuccess?: () => void;
 };
 
-export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSuccess }) => {
+export const ProductsFormModal: FC<Props> = ({
+  action,
+  onCancel,
+  onMutationSuccess,
+}) => {
   const [form] = Form.useForm();
   const [open, setOpen] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -79,35 +95,36 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
     navigate("/products");
   };
 
+  const handleOk = async () => {
+    try {
+      const values = await form.validateFields();
+      setLoading(true);
+
+      await mutateAsync({
+        values: {
+          title: values.name,
+          description: values.description,
+          unitPrice: Number(values.salesPrice || 0),
+        },
+      });
+
+      onMutationSuccess?.();
+      setOpen(false);
+      navigate("/products");
+    } catch (error: any) {
+      console.error("create product error", error);
+      message.error(error?.message || "Có lỗi xảy ra!");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <Modal
       open={open}
       title={action === "create" ? "Create Product" : "Edit Product"}
       onCancel={handleClose}
-      onOk={() => {
-        form.validateFields().then(async (values) => {
-          setLoading(true);
-          try {
-            await mutateAsync({
-              values: {
-                name: values.name,
-                internalReference: values.internalReference,
-                responsible: values.responsible,
-                productTags: values.tags || [],
-                description: values.description,
-                salesPrice: Number(values.salesPrice || 0),
-                cost: Number(values.cost || 0),
-                unitOfMeasure: values.unitOfMeasure,
-              },
-            });
-            onMutationSuccess?.();
-            setOpen(false);
-            navigate("/products");
-          } finally {
-            setLoading(false);
-          }
-        });
-      }}
+      onOk={handleOk}
       confirmLoading={loading}
       width={900}
       destroyOnClose
@@ -130,62 +147,121 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
             <Tabs.TabPane tab="General Information" key="general">
               <Row gutter={16}>
                 <Col span={12}>
-                  <Form.Item name="name" label="Product Name" rules={[{ required: true }]}> 
+                  <Form.Item
+                    name="name"
+                    label="Product Name"
+                    rules={[{ required: true }]}
+                  >
                     <Input placeholder="e.g. Cheese Burger" />
                   </Form.Item>
                   <Form.Item label="Can be Sold / Purchased">
-                    <Form.Item name="canBeSold" valuePropName="checked" initialValue={true} noStyle>
-                      <Checkbox style={{ marginRight: 24 }}>Can be Sold</Checkbox>
+                    <Form.Item
+                      name="canBeSold"
+                      valuePropName="checked"
+                      initialValue={true}
+                      noStyle
+                    >
+                      <Checkbox style={{ marginRight: 24 }}>
+                        Can be Sold
+                      </Checkbox>
                     </Form.Item>
-                    <Form.Item name="canBePurchased" valuePropName="checked" initialValue={true} noStyle>
+                    <Form.Item
+                      name="canBePurchased"
+                      valuePropName="checked"
+                      initialValue={true}
+                      noStyle
+                    >
                       <Checkbox>Can be Purchased</Checkbox>
                     </Form.Item>
                   </Form.Item>
-                  <Form.Item name="productType" label="Product Type" rules={[{ required: true }]}> 
+                  <Form.Item
+                    name="productType"
+                    label="Product Type"
+                    rules={[{ required: true }]}
+                  >
                     <Select options={PRODUCT_TYPES} placeholder="Select type" />
                   </Form.Item>
-                  <Form.Item name="invoicingPolicy" label="Invoicing Policy"> 
-                    <Select options={INVOICING_POLICIES} placeholder="Select policy" />
+                  <Form.Item name="invoicingPolicy" label="Invoicing Policy">
+                    <Select
+                      options={INVOICING_POLICIES}
+                      placeholder="Select policy"
+                    />
                   </Form.Item>
                   {productType === "service" && (
                     <Form.Item name="createOnOrder" label="Create on Order">
-                      <Select options={CREATE_ON_ORDER_OPTIONS} placeholder="Select option" />
+                      <Select
+                        options={CREATE_ON_ORDER_OPTIONS}
+                        placeholder="Select option"
+                      />
                     </Form.Item>
                   )}
-                  <Form.Item name="reInvoiceExpenses" label="Re-Invoice Expenses">
+                  <Form.Item
+                    name="reInvoiceExpenses"
+                    label="Re-Invoice Expenses"
+                  >
                     <Select options={REINVOICE_EXPENSES} />
                   </Form.Item>
-                  <Form.Item name="unitOfMeasure" label="Unit of Measure"> 
+                  <Form.Item name="unitOfMeasure" label="Unit of Measure">
                     <Select options={UOM_OPTIONS} placeholder="Select UoM" />
                   </Form.Item>
-                  <Form.Item name="purchaseUoM" label="Purchase UoM"> 
-                    <Select options={UOM_OPTIONS} placeholder="Select Purchase UoM" />
+                  <Form.Item name="purchaseUoM" label="Purchase UoM">
+                    <Select
+                      options={UOM_OPTIONS}
+                      placeholder="Select Purchase UoM"
+                    />
                   </Form.Item>
                   <Form.Item name="description" label={<b>Internal Notes</b>}>
-                    <Input.TextArea rows={3} placeholder="This note is only for internal purposes." />
+                    <Input.TextArea
+                      rows={3}
+                      placeholder="This note is only for internal purposes."
+                    />
                   </Form.Item>
                 </Col>
                 <Col span={12}>
-                  <Form.Item name="salesPrice" label="Sales Price" rules={[{ required: true }]}> 
-                    <InputNumber min={0} style={{ width: "100%" }} placeholder="e.g. 1.00" addonAfter="$" />
+                  <Form.Item
+                    name="salesPrice"
+                    label="Sales Price"
+                    rules={[{ required: true }]}
+                  >
+                    <InputNumber
+                      min={0}
+                      style={{ width: "100%" }}
+                      placeholder="e.g. 1.00"
+                      addonAfter="$"
+                    />
                   </Form.Item>
                   <Form.Item name="customerTaxes" label="Customer Taxes">
                     <Select options={TAX_OPTIONS} placeholder="Select tax" />
                   </Form.Item>
-                  <Form.Item name="cost" label="Cost"> 
-                    <InputNumber min={0} style={{ width: "100%" }} placeholder="e.g. 0.00" addonAfter="$" />
+                  <Form.Item name="cost" label="Cost">
+                    <InputNumber
+                      min={0}
+                      style={{ width: "100%" }}
+                      placeholder="e.g. 0.00"
+                      addonAfter="$"
+                    />
                   </Form.Item>
-                  <Form.Item name="category" label="Product Category"> 
-                    <Select options={CATEGORY_OPTIONS} placeholder="Select category" />
+                  <Form.Item name="category" label="Product Category">
+                    <Select
+                      options={CATEGORY_OPTIONS}
+                      placeholder="Select category"
+                    />
                   </Form.Item>
-                  <Form.Item name="internalReference" label="Internal Reference"> 
+                  <Form.Item
+                    name="internalReference"
+                    label="Internal Reference"
+                  >
                     <Input placeholder="SKU/Code" />
                   </Form.Item>
-                  <Form.Item name="barcode" label="Barcode"> 
+                  <Form.Item name="barcode" label="Barcode">
                     <Input placeholder="Barcode" />
                   </Form.Item>
-                  <Form.Item name="tags" label="Product Tags"> 
-                    <Select mode="tags" style={{ width: "100%" }} placeholder="Add tags" />
+                  <Form.Item name="tags" label="Product Tags">
+                    <Select
+                      mode="tags"
+                      style={{ width: "100%" }}
+                      placeholder="Add tags"
+                    />
                   </Form.Item>
                 </Col>
               </Row>
@@ -207,26 +283,48 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
                 <Row gutter={16}>
                   <Col span={12}>
                     <Form.Item name="weight" label="Weight">
-                      <InputNumber min={0} style={{ width: "100%" }} placeholder="0.00" addonAfter="kg" />
+                      <InputNumber
+                        min={0}
+                        style={{ width: "100%" }}
+                        placeholder="0.00"
+                        addonAfter="kg"
+                      />
                     </Form.Item>
                   </Col>
                   <Col span={12}>
                     <Form.Item name="volume" label="Volume">
-                      <InputNumber min={0} style={{ width: "100%" }} placeholder="0.00" addonAfter="m³" />
+                      <InputNumber
+                        min={0}
+                        style={{ width: "100%" }}
+                        placeholder="0.00"
+                        addonAfter="m³"
+                      />
                     </Form.Item>
                   </Col>
                 </Row>
                 <Row gutter={16}>
                   <Col span={24}>
-                    <Form.Item name="receiptNote" label="Description for Receipts">
-                      <Input.TextArea rows={2} placeholder="This note is added to receipt orders..." />
+                    <Form.Item
+                      name="receiptNote"
+                      label="Description for Receipts"
+                    >
+                      <Input.TextArea
+                        rows={2}
+                        placeholder="This note is added to receipt orders..."
+                      />
                     </Form.Item>
                   </Col>
                 </Row>
                 <Row gutter={16}>
                   <Col span={24}>
-                    <Form.Item name="deliveryNote" label="Description for Delivery Orders">
-                      <Input.TextArea rows={2} placeholder="This note is added to delivery orders..." />
+                    <Form.Item
+                      name="deliveryNote"
+                      label="Description for Delivery Orders"
+                    >
+                      <Input.TextArea
+                        rows={2}
+                        placeholder="This note is added to delivery orders..."
+                      />
                     </Form.Item>
                   </Col>
                 </Row>
@@ -237,7 +335,10 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
                 <Row gutter={16}>
                   <Col span={12}>
                     <Form.Item name="salesNote" label="Sales Note">
-                      <Input.TextArea rows={2} placeholder="This note is added to sales orders..." />
+                      <Input.TextArea
+                        rows={2}
+                        placeholder="This note is added to sales orders..."
+                      />
                     </Form.Item>
                   </Col>
                 </Row>
@@ -248,7 +349,10 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
                 <Row gutter={16}>
                   <Col span={12}>
                     <Form.Item name="vendorTaxes" label="Vendor Taxes">
-                      <Select options={TAX_OPTIONS} placeholder="Select vendor tax" />
+                      <Select
+                        options={TAX_OPTIONS}
+                        placeholder="Select vendor tax"
+                      />
                     </Form.Item>
                   </Col>
                 </Row>
@@ -258,19 +362,28 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
               <Row gutter={16}>
                 <Col span={12}>
                   <Form.Item name="incomeAccount" label="Income Account">
-                    <Select options={ACCOUNT_OPTIONS} placeholder="Select income account" />
+                    <Select
+                      options={ACCOUNT_OPTIONS}
+                      placeholder="Select income account"
+                    />
                   </Form.Item>
                 </Col>
                 <Col span={12}>
                   <Form.Item name="expenseAccount" label="Expense Account">
-                    <Select options={ACCOUNT_OPTIONS} placeholder="Select expense account" />
+                    <Select
+                      options={ACCOUNT_OPTIONS}
+                      placeholder="Select expense account"
+                    />
                   </Form.Item>
                 </Col>
               </Row>
               <Row gutter={16}>
                 <Col span={12}>
                   <Form.Item name="assetType" label="Asset Type">
-                    <Select options={ASSET_TYPE_OPTIONS} placeholder="Select asset type" />
+                    <Select
+                      options={ASSET_TYPE_OPTIONS}
+                      placeholder="Select asset type"
+                    />
                   </Form.Item>
                 </Col>
               </Row>

--- a/frontend-graphql/app-crm/src/routes/sales/products/list.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/list.tsx
@@ -11,19 +11,18 @@ import {
 } from "@refinedev/antd";
 import { getDefaultFilter, type HttpError } from "@refinedev/core";
 import { SearchOutlined } from "@ant-design/icons";
-import { Form, Grid, Input, Space, Spin, Table, Avatar } from "antd";
-import dayjs from "dayjs";
+import { Form, Grid, Input, Space, Spin, Table } from "antd";
 import debounce from "lodash/debounce";
 
-import { ListTitleButton, PaginationTotal, Text, CustomAvatar } from "@/components";
+import { ListTitleButton, PaginationTotal, CustomAvatar } from "@/components";
 import { PRODUCTS_TABLE_QUERY } from "./queries";
 
 // TODO: Thay thế bằng type thực tế của Product
 // type Product = GetFieldsFromList<ProductsTableQuery>;
 type Product = {
   id: string;
-  name: string;
-  price: number;
+  title: string;
+  unitPrice: number;
   createdAt: string;
   image?: string;
 };
@@ -32,11 +31,11 @@ type Product = {
 const mockProducts = [
   {
     id: "1",
-    name: "yyyyy",
+    title: "yyyyy",
     internalReference: "REF001",
     responsible: "Administrator",
     productTags: ["tag1", "tag2", "tag3"],
-    salesPrice: 0.0,
+    unitPrice: 0.0,
     cost: 0.0,
     quantityOnHand: 10,
     forecastedQuantity: 12,
@@ -44,11 +43,11 @@ const mockProducts = [
   },
   {
     id: "2",
-    name: "Service on Timesheet",
+    title: "Service on Timesheet",
     internalReference: "REF002",
     responsible: "Administrator",
     productTags: [],
-    salesPrice: 40.0,
+    unitPrice: 40.0,
     cost: 0.0,
     quantityOnHand: 0,
     forecastedQuantity: 0,
@@ -56,11 +55,11 @@ const mockProducts = [
   },
   {
     id: "3",
-    name: "Senior Developer (Timesheet)",
+    title: "Senior Developer (Timesheet)",
     internalReference: "REF003",
     responsible: "Administrator",
     productTags: [],
-    salesPrice: 20.0,
+    unitPrice: 20.0,
     cost: 0.0,
     quantityOnHand: 0,
     forecastedQuantity: 0,
@@ -77,19 +76,17 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
     filters,
     sorters,
     tableQuery: tableQueryResult,
-  } = useTable<Product, HttpError, { name: string }>({
+  } = useTable<Product, HttpError, { title: string }>({
     resource: "products",
     onSearch: (values) => [
       {
-        field: "name",
+        field: "title",
         operator: "contains",
-        value: values.name,
+        value: values.title,
       },
     ],
     filters: {
-      initial: [
-        { field: "name", value: "", operator: "contains" },
-      ],
+      initial: [{ field: "title", value: "", operator: "contains" }],
     },
     sorters: {
       initial: [{ field: "createdAt", order: "desc" }],
@@ -101,7 +98,7 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
 
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     searchFormProps?.onFinish?.({
-      name: e.target.value ?? "",
+      title: e.target.value ?? "",
     });
   };
 
@@ -116,7 +113,7 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
 
   return (
     <div className="page-container">
-      <div style={{ padding: 24, background: '#fff', borderRadius: 8 }}>
+      <div style={{ padding: 24, background: "#fff", borderRadius: 8 }}>
         <List
           breadcrumb={false}
           headerButtons={() => {
@@ -129,11 +126,11 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
                 <Form
                   {...searchFormProps}
                   initialValues={{
-                    name: getDefaultFilter("name", filters, "contains"),
+                    title: getDefaultFilter("title", filters, "contains"),
                   }}
                   layout="inline"
                 >
-                  <Form.Item name="name" noStyle>
+                  <Form.Item name="title" noStyle>
                     <Input
                       size="large"
                       prefix={<SearchOutlined />}
@@ -143,7 +140,7 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
                           spinning={tableQueryResult.isFetching}
                         />
                       }
-                      placeholder="Search by name"
+                      placeholder="Search by title"
                       onChange={debouncedOnChange}
                     />
                   </Form.Item>
@@ -170,84 +167,29 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
             rowKey="id"
           >
             <Table.Column
-              dataIndex="name"
-              title="Product Name"
+              dataIndex="title"
+              title="Product Title"
               width={200}
               sorter
               render={(_, record) => (
                 <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                  <CustomAvatar name={record.name} src={record.image} shape="square" size={28} style={{ marginRight: 6 }} />
-                  {record.name}
-                </span>
-              )}
-            />
-            <Table.Column dataIndex="internalReference" title="Internal Reference" width={140} sorter />
-            <Table.Column
-              dataIndex="responsible"
-              title="Responsible"
-              width={140}
-              sorter
-              render={value => (
-                <span>
-                  <Avatar style={{ backgroundColor: '#c44', marginRight: 6 }} size={24}>A</Avatar>
-                  {value}
+                  <CustomAvatar
+                    name={record.title}
+                    src={record.image}
+                    shape="square"
+                    size={28}
+                    style={{ marginRight: 6 }}
+                  />
+                  {record.title}
                 </span>
               )}
             />
             <Table.Column
-              dataIndex="productTags"
-              title="Product Tags"
-              width={180}
-              sorter
-              render={tags => (
-                <span style={{
-                  display: "inline-block",
-                  maxWidth: 120,
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis"
-                }}>
-                  {tags?.join(", ")}
-                </span>
-              )}
-            />
-            <Table.Column
-              dataIndex="salesPrice"
-              title="Sales Price"
+              dataIndex="unitPrice"
+              title="Unit Price"
               width={100}
               sorter
-              render={value => `${value.toFixed(2)} €`}
-            />
-            <Table.Column
-              dataIndex="status"
-              title="Status"
-              width={120}
-              sorter
-            />
-            <Table.Column
-              dataIndex="cost"
-              title="Cost"
-              width={100}
-              sorter
-              render={value => `${value.toFixed(2)} €`}
-            />
-            <Table.Column
-              dataIndex="quantityOnHand"
-              title="Quantity On Hand"
-              width={120}
-              sorter
-            />
-            <Table.Column
-              dataIndex="forecastedQuantity"
-              title="Forecasted Quantity"
-              width={140}
-              sorter
-            />
-            <Table.Column
-              dataIndex="unitOfMeasure"
-              title="Unit of Measure"
-              width={120}
-              sorter
+              render={(value) => `${value.toFixed(2)} €`}
             />
             <Table.Column
               fixed="right"

--- a/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
+++ b/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
@@ -1,21 +1,17 @@
 import { gql } from "@apollo/client";
 
 export const PRODUCTS_TABLE_QUERY = gql`
-  query ProductsTable($filter: FilterInput, $sorting: [SortInput!], $paging: OffsetPagingInput) {
+  query ProductsTable(
+    $filter: FilterInput
+    $sorting: [SortInput!]
+    $paging: OffsetPagingInput
+  ) {
     products(filter: $filter, sorting: $sorting, paging: $paging) {
       nodes {
         id
-        name
-        internalReference
-        responsible
-        productTags
-        status
-        salesPrice
-        cost
-        quantityOnHand
-        forecastedQuantity
-        unitOfMeasure
-        image
+        title
+        description
+        unitPrice
         createdAt
       }
       totalCount
@@ -27,18 +23,9 @@ export const PRODUCT_CREATE_MUTATION = gql`
   mutation CreateProduct($data: CreateProductInput!) {
     createProduct(data: $data) {
       id
-      name
+      title
       description
-      internalReference
-      responsible
-      productTags
-      salesPrice
-      cost
-      quantityOnHand
-      forecastedQuantity
-      unitOfMeasure
-      status
-      categoryId
+      unitPrice
     }
   }
 `;


### PR DESCRIPTION
## Summary
- align product GraphQL queries with server schema
- send `title` and `unitPrice` when creating products
- update product list page and mock data to use new fields

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm test` in `frontend-graphql/app-crm` *(fails: jest not found)*
- `npm run lint` in `frontend-graphql/app-crm` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685f901dbd548331a3a5d55a784685f0