### PR TITLE
Fix duplicate imports in product form modal

### DIFF
--- a/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
@@ -14,8 +14,6 @@ import {
   message,
 } from "antd";
 
-import { Modal, Form, Input, InputNumber, Select, Spin, Checkbox, Row, Col, Tabs, message } from "antd";
-
 import { useNavigate } from "react-router-dom";
 import { type HttpError, useCreate } from "@refinedev/core";
 import styles from "./index.module.css";
@@ -105,14 +103,6 @@ export const ProductsFormModal: FC<Props> = ({
 
       await mutateAsync({
         values: {
-          title: values.name,
-          description: values.description,
-          unitPrice: Number(values.salesPrice || 0),
-
-          title: values.name,
-          description: values.description,
-          unitPrice: Number(values.salesPrice || 0),
-
           name: values.name,
           internalReference: values.internalReference,
           responsible: values.responsible,
@@ -121,7 +111,6 @@ export const ProductsFormModal: FC<Props> = ({
           salesPrice: Number(values.salesPrice || 0),
           cost: Number(values.cost || 0),
           unitOfMeasure: values.unitOfMeasure,
-
         },
       });
 
@@ -130,9 +119,6 @@ export const ProductsFormModal: FC<Props> = ({
       navigate("/products");
     } catch (error: any) {
       console.error("create product error", error);
-      message.error(error?.message || "Có lỗi xảy ra!");
-
-
       message.error(error?.message || "Có lỗi xảy ra!");
 
     } finally {


### PR DESCRIPTION
## Summary
- fix duplicate Ant Design imports in `form-modal.tsx`
- remove extra fields and duplicates in the submit handler

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f9cba6c708331b808d816d1b44dbf