### PR TITLE
Fix non-interactive migrations

### DIFF
--- a/graphql-typegraphql-crud-final/docker-compose.yml
+++ b/graphql-typegraphql-crud-final/docker-compose.yml
@@ -35,8 +35,8 @@ services:
         npx prisma generate &&
         echo '⏳ Waiting for PostgreSQL...' &&
         until nc -z postgres 5432; do sleep 1; done &&
-        echo '🚀 Creating and applying migrations...' &&
-        npx prisma migrate dev --name init --skip-seed &&
+        echo '🚀 Applying migrations...' &&
+        npx prisma migrate deploy &&
         echo '🟢 Starting development server with hot reload on port 8000...' &&
         npm run dev
       "


### PR DESCRIPTION
## Summary
- fix docker compose to apply migrations non-interactively with `prisma migrate deploy`

## Testing
- `npm test` *(fails: Missing script)*
- `(cd graphql-typegraphql-crud-final && npm test)` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861f0f7fb648331b6fdc770e56b923e