### PR TITLE
Fix product creation

### DIFF
--- a/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
@@ -2,6 +2,7 @@ import type { FC } from "react";
 import { useState } from "react";
 import { Modal, Form, Input, InputNumber, Select, Spin, Checkbox, Row, Col, Tabs } from "antd";
 import { useNavigate } from "react-router-dom";
+import { dataProvider, API_URL } from "@/providers/data";
 import styles from "./index.module.css";
 
 const PRODUCT_TYPES = [
@@ -79,15 +80,36 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
       title={action === "create" ? "Create Product" : "Edit Product"}
       onCancel={handleClose}
       onOk={() => {
-        form.validateFields().then((values) => {
+        form.validateFields().then(async (values) => {
           setLoading(true);
-          // TODO: Gọi mutation tạo/sửa sản phẩm ở đây
-          setTimeout(() => {
+          try {
+            await dataProvider.custom({
+              url: API_URL,
+              method: "post",
+              meta: {
+                variables: {
+                  data: {
+                    title: values.name,
+                    description: values.description,
+                    unitPrice: Number(values.salesPrice),
+                  },
+                },
+                rawQuery: `
+                  mutation CreateProduct($data: CreateProductInput!) {
+                    createProduct(data: $data) {
+                      id
+                    }
+                  }
+                `,
+              },
+            });
             setLoading(false);
             onMutationSuccess?.();
             setOpen(false);
             navigate("/products");
-          }, 800);
+          } catch {
+            setLoading(false);
+          }
         });
       }}
       confirmLoading={loading}

--- a/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
+++ b/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
@@ -21,3 +21,15 @@ export const PRODUCTS_TABLE_QUERY = gql`
     }
   }
 `;
+
+export const PRODUCTS_CREATE_MUTATION = gql`
+  mutation ProductsCreate($data: CreateProductInput!) {
+    createProduct(data: $data) {
+      id
+      title
+      description
+      unitPrice
+      categoryId
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- implement `PRODUCTS_CREATE_MUTATION` query
- wire product form modal to call `createProduct` mutation via dataProvider

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in backend *(fails: missing script)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686211a14fc48331804aa8bec5f6e80b