### PR TITLE
Fix product list query and search filters

### DIFF
--- a/frontend-graphql/app-crm/src/routes/sales/products/list.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/list.tsx
@@ -77,18 +77,18 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
     filters,
     sorters,
     tableQuery: tableQueryResult,
-  } = useTable<Product, HttpError, { name: string }>({
+  } = useTable<Product, HttpError, { title: string }>({
     resource: "products",
     onSearch: (values) => [
       {
-        field: "name",
+        field: "title",
         operator: "contains",
-        value: values.name,
+        value: values.title,
       },
     ],
     filters: {
       initial: [
-        { field: "name", value: "", operator: "contains" },
+        { field: "title", value: "", operator: "contains" },
       ],
     },
     sorters: {
@@ -101,7 +101,7 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
 
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     searchFormProps?.onFinish?.({
-      name: e.target.value ?? "",
+      title: e.target.value ?? "",
     });
   };
 
@@ -138,11 +138,11 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
                 <Form
                   {...searchFormProps}
                   initialValues={{
-                    name: getDefaultFilter("name", filters, "contains"),
+                    title: getDefaultFilter("title", filters, "contains"),
                   }}
                   layout="inline"
                 >
-                  <Form.Item name="name" noStyle>
+                  <Form.Item name="title" noStyle>
                     <Input
                       size="large"
                       prefix={<SearchOutlined />}

--- a/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
+++ b/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const PRODUCTS_TABLE_QUERY = gql`
-  query ProductsTable($filter: FilterInput, $sorting: [SortInput!], $paging: OffsetPagingInput) {
+  query ProductsTable($filter: ProductFilter, $sorting: [ProductSort!], $paging: OffsetPaging) {
     products(filter: $filter, sorting: $sorting, paging: $paging) {
       nodes {
         id


### PR DESCRIPTION
## Summary
- fix GraphQL query variable types for ProductsTable
- search products by title instead of name

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638a2ca5ac83319b07cae82a568939