### PR TITLE
Rename product fields across backend and frontend

### DIFF
--- a/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
@@ -91,9 +91,9 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
                 meta: {
                   variables: {
                     data: {
-                      title: values.name,
+                      name: values.name,
                       description: values.description,
-                      unitPrice: Number(values.salesPrice),
+                      salesPrice: Number(values.salesPrice),
                       status: values.status || "active", // thêm status
                     },
                   },
@@ -101,7 +101,7 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
                     mutation CreateProduct($data: CreateProductInput!) {
                       createProduct(data: $data) {
                         id
-                        title
+                        name
                         status
                       }
                     }

--- a/frontend-graphql/app-crm/src/routes/sales/products/list.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/list.tsx
@@ -82,17 +82,17 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
     filters,
     sorters,
     tableQuery: tableQueryResult,
-  } = useTable<Product, HttpError, { title: string }>({
+  } = useTable<Product, HttpError, { name: string }>({
     resource: "products",
     onSearch: (values) => [
       {
-        field: "title",
+        field: "name",
         operator: "contains",
-        value: values.title,
+        value: values.name,
       },
     ],
     filters: {
-      initial: [{ field: "title", value: "", operator: "contains" }],
+      initial: [{ field: "name", value: "", operator: "contains" }],
     },
     sorters: {
       initial: [{ field: "createdAt", order: "desc" }],
@@ -104,7 +104,7 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
 
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     searchFormProps?.onFinish?.({
-      title: e.target.value ?? "",
+      name: e.target.value ?? "",
     });
   };
 
@@ -114,8 +114,6 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
     ? tableProps.dataSource.map((product: any) => ({
         ...product,
         id: product._id ?? product.id,
-        name: product.title, // map title -> name
-        salesPrice: product.unitPrice, // map unitPrice -> salesPrice
       }))
     : [];
 
@@ -134,11 +132,11 @@ export const ProductsListPage: FC<PropsWithChildren> = ({ children }) => {
                 <Form
                   {...searchFormProps}
                   initialValues={{
-                    title: getDefaultFilter("title", filters, "contains"),
+                    name: getDefaultFilter("name", filters, "contains"),
                   }}
                   layout="inline"
                 >
-                  <Form.Item name="title" noStyle>
+                  <Form.Item name="name" noStyle>
                     <Input
                       size="large"
                       prefix={<SearchOutlined />}

--- a/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
+++ b/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
@@ -5,11 +5,11 @@ export const PRODUCTS_TABLE_QUERY = gql`
     products(filter: $filter, sorting: $sorting, paging: $paging) {
       nodes {
         id
-        title
+        name
         internalReference
         responsible
         productTags
-        unitPrice
+        salesPrice
         cost
         quantityOnHand
         forecastedQuantity
@@ -26,11 +26,11 @@ export const PRODUCTS_CREATE_MUTATION = gql`
   mutation ProductsCreate($data: CreateProductInput!) {
     createProduct(data: $data) {
         id
-        title
+        name
         internalReference
         responsible
         productTags
-        unitPrice
+        salesPrice
         cost
         quantityOnHand
         forecastedQuantity

--- a/frontend-graphql/app-crm/src/routes/sales/quotes/queries.ts
+++ b/frontend-graphql/app-crm/src/routes/sales/quotes/queries.ts
@@ -14,8 +14,8 @@ const QUOTE_FRAGMENT = gql`
             id
             product {
                 id
-                title
-                unitPrice
+                name
+                salesPrice
             }
             quantity
             discount

--- a/graphql-typegraphql-crud-final/prisma/schema.prisma
+++ b/graphql-typegraphql-crud-final/prisma/schema.prisma
@@ -157,23 +157,23 @@ model Category {
 }
 
 model Product {
-  id                Int      @id @default(autoincrement())
-  title             String
-  internalReference String?
-  responsible       String?
-  description       String?
-  productTags       String?
-  unitPrice         Float
-  cost              Float    @default(0)
-  quantityOnHand    String?
-  forecastedQuantity String?
-  unitOfMeasure     String?
-  status            String   @default("active")
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
-  categoryId        Int?
-  category          Category? @relation("ProductCategory", fields: [categoryId], references: [id])
-  quotes            QuoteProduct[] @relation("QuoteProducts")
+  id                 Int      @id @default(autoincrement())
+  name               String
+  internalReference  String?
+  responsible        String?
+  description        String?
+  productTags        String?
+  salesPrice         Float
+  cost               Float    @default(0)
+  quantityOnHand     Int?
+  forecastedQuantity Int?
+  unitOfMeasure      String?
+  status             String   @default("active")
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+  categoryId         Int?
+  category           Category?   @relation("ProductCategory", fields: [categoryId], references: [id])
+  quotes             QuoteProduct[] @relation("QuoteProducts")
 }
 
 

--- a/graphql-typegraphql-crud-final/prisma/seed.ts
+++ b/graphql-typegraphql-crud-final/prisma/seed.ts
@@ -103,11 +103,11 @@ async function main() {
   // 7. Product
   await prisma.product.createMany({
     data: [
-      { id: 1, title: "Product 1", description: "Desc 1", unitPrice: 10, categoryId: 1 },
-      { id: 2, title: "Product 2", description: "Desc 2", unitPrice: 20, categoryId: 2 },
-      { id: 3, title: "Product 3", description: "Desc 3", unitPrice: 30, categoryId: 3 },
-      { id: 4, title: "Product 4", description: "Desc 4", unitPrice: 40, categoryId: 4 },
-      { id: 5, title: "Product 5", description: "Desc 5", unitPrice: 50, categoryId: 5 },
+      { id: 1, name: "Product 1", description: "Desc 1", salesPrice: 10, categoryId: 1 },
+      { id: 2, name: "Product 2", description: "Desc 2", salesPrice: 20, categoryId: 2 },
+      { id: 3, name: "Product 3", description: "Desc 3", salesPrice: 30, categoryId: 3 },
+      { id: 4, name: "Product 4", description: "Desc 4", salesPrice: 40, categoryId: 4 },
+      { id: 5, name: "Product 5", description: "Desc 5", salesPrice: 50, categoryId: 5 },
     ],
     skipDuplicates: true,
   });

--- a/graphql-typegraphql-crud-final/src/resolvers/ProductResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/ProductResolver.ts
@@ -18,17 +18,29 @@ export class ProductResolver {
     @Arg("paging", () => OffsetPaging, { nullable: true }) paging: OffsetPaging
   ): Promise<ProductListResponse> {
     const where: any = {};
-    if (filter?.title) {
-      if (typeof filter.title === 'string') {
-        if ((filter.title as string).trim() !== '' && filter.title !== '%%') {
-          where.title = { contains: filter.title as string };
+    if (filter?.name) {
+      if (typeof filter.name === 'string') {
+        if ((filter.name as string).trim() !== '' && filter.name !== '%%') {
+          where.name = { contains: filter.name as string };
         }
-      } else if (typeof filter.title.iLike === 'string' && filter.title.iLike !== '%%' && filter.title.iLike.trim() !== '') {
-        where.title = { contains: filter.title.iLike, mode: 'insensitive' };
-      } else if (typeof filter.title.contains === 'string' && filter.title.contains.trim() !== '' && filter.title.contains !== '%%') {
-        where.title = { contains: filter.title.contains };
-      } else if (typeof filter.title.eq === 'string' && filter.title.eq.trim() !== '' && filter.title.eq !== '%%') {
-        where.title = filter.title.eq;
+      } else if (
+        typeof filter.name.iLike === 'string' &&
+        filter.name.iLike !== '%%' &&
+        filter.name.iLike.trim() !== ''
+      ) {
+        where.name = { contains: filter.name.iLike, mode: 'insensitive' };
+      } else if (
+        typeof filter.name.contains === 'string' &&
+        filter.name.contains.trim() !== '' &&
+        filter.name.contains !== '%%'
+      ) {
+        where.name = { contains: filter.name.contains };
+      } else if (
+        typeof filter.name.eq === 'string' &&
+        filter.name.eq.trim() !== '' &&
+        filter.name.eq !== '%%'
+      ) {
+        where.name = filter.name.eq;
       }
     }
 

--- a/graphql-typegraphql-crud-final/src/resolvers/QuoteFieldResolver.ts
+++ b/graphql-typegraphql-crud-final/src/resolvers/QuoteFieldResolver.ts
@@ -11,7 +11,7 @@ export class QuoteFieldResolver {
     }
     
     return quote.items.reduce((total, item) => {
-      return total + (item.quantity * item.product.unitPrice);
+      return total + item.quantity * item.product.salesPrice;
     }, 0);
   }
 

--- a/graphql-typegraphql-crud-final/src/schema/Product.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Product.ts
@@ -6,7 +6,7 @@ export class Product {
   id: number;
 
   @Field()
-  title: string;
+  name: string;
 
   @Field({ nullable: true })
   internalReference?: string;
@@ -21,16 +21,16 @@ export class Product {
   productTags?: string;
 
   @Field()
-  unitPrice: number;
+  salesPrice: number;
 
   @Field()
   cost: number;
 
   @Field({ nullable: true })
-  quantityOnHand?: string;
+  quantityOnHand?: number;
 
   @Field({ nullable: true })
-  forecastedQuantity?: string;
+  forecastedQuantity?: number;
 
   @Field({ nullable: true })
   unitOfMeasure?: string;

--- a/graphql-typegraphql-crud-final/src/schema/ProductFilter.ts
+++ b/graphql-typegraphql-crud-final/src/schema/ProductFilter.ts
@@ -4,5 +4,5 @@ import { StringFilter } from "./StringFilter";
 @InputType()
 export class ProductFilter {
   @Field(() => StringFilter, { nullable: true })
-  title?: StringFilter;
+  name?: StringFilter;
 }

--- a/graphql-typegraphql-crud-final/src/schema/ProductInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/ProductInput.ts
@@ -3,7 +3,7 @@ import { Field, InputType } from "type-graphql";
 @InputType()
 export class CreateProductInput {
   @Field()
-  title: string;
+  name: string;
 
   @Field({ nullable: true })
   internalReference?: string;
@@ -18,16 +18,16 @@ export class CreateProductInput {
   productTags?: string;
 
   @Field()
-  unitPrice: number;
+  salesPrice: number;
 
   @Field({ nullable: true })
   cost?: number;
 
   @Field({ nullable: true })
-  quantityOnHand?: string;
+  quantityOnHand?: number;
 
   @Field({ nullable: true })
-  forecastedQuantity?: string;
+  forecastedQuantity?: number;
 
   @Field({ nullable: true })
   unitOfMeasure?: string;
@@ -42,7 +42,7 @@ export class CreateProductInput {
 @InputType()
 export class UpdateProductInput {
   @Field({ nullable: true })
-  title?: string;
+  name?: string;
 
   @Field({ nullable: true })
   internalReference?: string;
@@ -57,16 +57,16 @@ export class UpdateProductInput {
   productTags?: string;
 
   @Field({ nullable: true })
-  unitPrice?: number;
+  salesPrice?: number;
 
   @Field({ nullable: true })
   cost?: number;
 
   @Field({ nullable: true })
-  quantityOnHand?: string;
+  quantityOnHand?: number;
 
   @Field({ nullable: true })
-  forecastedQuantity?: string;
+  forecastedQuantity?: number;
 
   @Field({ nullable: true })
   unitOfMeasure?: string;


### PR DESCRIPTION
## Summary
- update Prisma Product model to use `name` and `salesPrice`
- adjust seed data for new fields
- refactor GraphQL Product schema and resolver logic
- update quote calculations to use `salesPrice`
- revise product GraphQL queries and React components to new field names

## Testing
- `npm test` in `frontend-graphql/app-crm` *(fails: jest not found)*
- `npm test` in `graphql-typegraphql-crud-final` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6864d48a3de08331a396393bf46e4048