### PR TITLE
Add startDate field to Project model

### DIFF
--- a/graphql-typegraphql-crud-final/prisma/schema.prisma
+++ b/graphql-typegraphql-crud-final/prisma/schema.prisma
@@ -220,6 +220,8 @@ model Project {
 
   tasks Task[]
 
+  startDate  DateTime?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }

--- a/graphql-typegraphql-crud-final/prisma/seed.ts
+++ b/graphql-typegraphql-crud-final/prisma/seed.ts
@@ -144,11 +144,41 @@ async function main() {
   // 10. Project
   await prisma.project.createMany({
     data: [
-      { id: 1, name: "Project 1", description: "Desc 1", createdById: 3 },
-      { id: 2, name: "Project 2", description: "Desc 2", createdById: 4 },
-      { id: 3, name: "Project 3", description: "Desc 3", createdById: 5 },
-      { id: 4, name: "Project 4", description: "Desc 4", createdById: 1 },
-      { id: 5, name: "Project 5", description: "Desc 5", createdById: 2 },
+      {
+        id: 1,
+        name: "Project 1",
+        description: "Desc 1",
+        createdById: 3,
+        startDate: new Date(),
+      },
+      {
+        id: 2,
+        name: "Project 2",
+        description: "Desc 2",
+        createdById: 4,
+        startDate: new Date(),
+      },
+      {
+        id: 3,
+        name: "Project 3",
+        description: "Desc 3",
+        createdById: 5,
+        startDate: new Date(),
+      },
+      {
+        id: 4,
+        name: "Project 4",
+        description: "Desc 4",
+        createdById: 1,
+        startDate: new Date(),
+      },
+      {
+        id: 5,
+        name: "Project 5",
+        description: "Desc 5",
+        createdById: 2,
+        startDate: new Date(),
+      },
     ],
     skipDuplicates: true,
   });

--- a/graphql-typegraphql-crud-final/src/schema/Project.ts
+++ b/graphql-typegraphql-crud-final/src/schema/Project.ts
@@ -14,6 +14,9 @@ export class Project {
   @Field({ nullable: true })
   createdById?: number;
 
+  @Field({ nullable: true })
+  startDate?: Date;
+
   @Field()
   createdAt: Date;
 

--- a/graphql-typegraphql-crud-final/src/schema/ProjectInput.ts
+++ b/graphql-typegraphql-crud-final/src/schema/ProjectInput.ts
@@ -10,6 +10,9 @@ export class CreateProjectInput {
 
   @Field({ nullable: true })
   createdById?: number;
+
+  @Field({ nullable: true })
+  startDate?: Date;
 }
 
 @InputType()
@@ -22,4 +25,7 @@ export class UpdateProjectInput {
 
   @Field({ nullable: true })
   createdById?: number;
+
+  @Field({ nullable: true })
+  startDate?: Date;
 }


### PR DESCRIPTION
## Summary
- allow setting a `startDate` for projects
- expose `startDate` on Project schema and inputs
- seed database with project start dates

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm test --silent` in backend *(no tests)*

------
https://chatgpt.com/codex/tasks/task_e_6866408e0a908331a6f69bd83aae1d47