### PR TITLE
Enable product show and edit pages

### DIFF
--- a/frontend-graphql/app-crm/src/App.tsx
+++ b/frontend-graphql/app-crm/src/App.tsx
@@ -60,7 +60,12 @@ import {
   SalesPage,
 } from "./routes/scrumboard/sales";
 import { UpdatePasswordPage } from "./routes/update-password";
-import { ProductsListPage, ProductsCreatePage } from "./routes/sales/products";
+import {
+  ProductsListPage,
+  ProductsCreatePage,
+  ProductsEditPage,
+  ProductsShowPage,
+} from "./routes/sales/products";
 import { InvoicesListPage, InvoicesShowPage } from "./routes/sales/invoices";
 import "./utilities/init-dayjs";
 import "@refinedev/antd/dist/reset.css";
@@ -263,6 +268,8 @@ const App: React.FC = () => {
                       }
                     >
                       <Route path="create" element={<ProductsCreatePage />} />
+                      <Route path="edit/:id" element={<ProductsEditPage />} />
+                      <Route path="show/:id" element={<ProductsShowPage />} />
                     </Route>
                     <Route path="/invoices" element={<InvoicesListPage />}>
                         {/* for invoices */}

--- a/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/components/form-modal/form-modal.tsx
@@ -1,9 +1,10 @@
 import type { FC } from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Modal, Form, Input, InputNumber, Select, Spin, Checkbox, Row, Col, Tabs,message } from "antd";
-import { useNavigate } from "react-router-dom";
-import { useInvalidate } from "@refinedev/core";
+import { useNavigate, useParams } from "react-router-dom";
+import { useInvalidate, useOne } from "@refinedev/core";
 import { dataProvider, API_URL } from "@/providers/data";
+import { PRODUCT_SHOW_QUERY } from "../../queries";
 import styles from "./index.module.css";
 
 const PRODUCT_TYPES = [
@@ -64,6 +65,22 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const invalidate = useInvalidate();
+  const params = useParams<{ id: string }>();
+
+  const { data: productData, isLoading: isLoadingProduct } = useOne({
+    resource: "products",
+    id: params.id,
+    queryOptions: { enabled: action === "edit" },
+    meta: { gqlQuery: PRODUCT_SHOW_QUERY },
+  });
+
+  useEffect(() => {
+    if (action === "edit" && productData?.data) {
+      form.setFieldsValue({
+        ...productData.data,
+      });
+    }
+  }, [action, productData, form]);
 
   // Theo dõi giá trị checkbox
   const canBeSold = Form.useWatch("canBeSold", form);
@@ -84,21 +101,13 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
       onOk={() => {
           form.validateFields().then(async (values) => {
             setLoading(true);
-            message.success("Successfully created product");
-            try {
-              await dataProvider.custom({
-                url: API_URL,
-                method: "post",
-                meta: {
-                  variables: {
-                    data: {
-                      name: values.name,
-                      description: values.description,
-                      salesPrice: Number(values.salesPrice),
-                      status: values.status || "active", // thêm status
-                    },
-                  },
-                  rawQuery: `
+            const variables =
+              action === "create"
+                ? { data: { name: values.name, description: values.description, salesPrice: Number(values.salesPrice), status: values.status || "active" } }
+                : { id: Number(params.id), data: { name: values.name, description: values.description, salesPrice: Number(values.salesPrice), status: values.status || "active" } };
+            const rawQuery =
+              action === "create"
+                ? `
                     mutation CreateProduct($data: CreateProductInput!) {
                       createProduct(data: $data) {
                         id
@@ -106,16 +115,40 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
                         status
                       }
                     }
-                  `,
+                  `
+                : `
+                    mutation UpdateProduct($id: ID!, $data: UpdateProductInput!) {
+                      updateProduct(id: $id, data: $data) {
+                        id
+                        name
+                        status
+                      }
+                    }
+                  `;
+            try {
+              await dataProvider.custom({
+                url: API_URL,
+                method: "post",
+                meta: {
+                  variables,
+                  rawQuery,
                 },
               });
               await invalidate({ resource: "products", invalidates: ["list"] });
+              message.success(
+                action === "create"
+                  ? "Successfully created product"
+                  : "Successfully updated product"
+              );
               setLoading(false);
               onMutationSuccess?.();
               setOpen(false);
               navigate("/products");
             } catch (error) {
-              console.error("Create product error:", error);
+              console.error(
+                action === "create" ? "Create product error:" : "Update product error:",
+                error
+              );
               setLoading(false);
             }
           });
@@ -125,19 +158,23 @@ export const ProductsFormModal: FC<Props> = ({ action, onCancel, onMutationSucce
       width={900}
       destroyOnClose
     >
-      <Spin spinning={loading}>
-        <Form 
-          form={form} 
+      <Spin spinning={loading || isLoadingProduct}>
+        <Form
+          form={form}
           layout="vertical"
-          initialValues={{
-            productType: "consumable",
-            invoicingPolicy: "ordered",
-            reInvoiceExpenses: "no",
-            unitOfMeasure: "Units",
-            purchaseUoM: "Units",
-            canBeSold: false,
-            canBePurchased: false,
-          }}
+          initialValues={
+            action === "create"
+              ? {
+                  productType: "consumable",
+                  invoicingPolicy: "ordered",
+                  reInvoiceExpenses: "no",
+                  unitOfMeasure: "Units",
+                  purchaseUoM: "Units",
+                  canBeSold: false,
+                  canBePurchased: false,
+                }
+              : undefined
+          }
         >
           <Tabs defaultActiveKey="general">
             <Tabs.TabPane tab="General Information" key="general">

--- a/frontend-graphql/app-crm/src/routes/sales/products/edit.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/edit.tsx
@@ -1,0 +1,12 @@
+import type { FC, PropsWithChildren } from "react";
+
+import { ProductsFormModal } from "./components";
+
+export const ProductsEditPage: FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <>
+      <ProductsFormModal action="edit" />
+      {children}
+    </>
+  );
+};

--- a/frontend-graphql/app-crm/src/routes/sales/products/index.ts
+++ b/frontend-graphql/app-crm/src/routes/sales/products/index.ts
@@ -1,3 +1,5 @@
 export * from "./list";
 export * from "./create";
+export * from "./edit";
+export * from "./show";
 

--- a/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
+++ b/frontend-graphql/app-crm/src/routes/sales/products/queries.ts
@@ -40,3 +40,41 @@ export const PRODUCTS_CREATE_MUTATION = gql`
     }
   }
 `;
+
+export const PRODUCT_SHOW_QUERY = gql`
+  query ProductShow($id: ID!) {
+    product(id: $id) {
+      id
+      name
+      internalReference
+      responsible
+      productTags
+      salesPrice
+      cost
+      quantityOnHand
+      forecastedQuantity
+      unitOfMeasure
+      status
+      createdAt
+    }
+  }
+`;
+
+export const PRODUCTS_UPDATE_MUTATION = gql`
+  mutation ProductsUpdate($id: ID!, $data: UpdateProductInput!) {
+    updateProduct(id: $id, data: $data) {
+      id
+      name
+      internalReference
+      responsible
+      productTags
+      salesPrice
+      cost
+      quantityOnHand
+      forecastedQuantity
+      unitOfMeasure
+      status
+      createdAt
+    }
+  }
+`;

--- a/frontend-graphql/app-crm/src/routes/sales/products/show/index.module.css
+++ b/frontend-graphql/app-crm/src/routes/sales/products/show/index.module.css
@@ -1,0 +1,11 @@
+.container {
+    max-width: 944px;
+    margin: 0 auto;
+}
+
+.title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}

--- a/frontend-graphql/app-crm/src/routes/sales/products/show/index.tsx
+++ b/frontend-graphql/app-crm/src/routes/sales/products/show/index.tsx
@@ -1,0 +1,67 @@
+import { Link, useParams } from "react-router-dom";
+import { useOne } from "@refinedev/core";
+import { Button, Descriptions, Space } from "antd";
+import { LeftOutlined, EditOutlined } from "@ant-design/icons";
+
+import { FullScreenLoading, Text } from "@/components";
+import { PRODUCT_SHOW_QUERY } from "../queries";
+import styles from "./index.module.css";
+
+export const ProductsShowPage = () => {
+  const { id } = useParams<{ id: string }>();
+
+  const { data, isLoading } = useOne({
+    resource: "products",
+    id,
+    meta: { gqlQuery: PRODUCT_SHOW_QUERY },
+  });
+
+  if (isLoading) {
+    return <FullScreenLoading />;
+  }
+
+  const record = data?.data;
+
+  if (!record) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.title}>
+        <Link to="/products">
+          {/* @ts-expect-error Ant Design Icon's v5.0.1 has an issue with @types/react@^18.2.66 */}
+          <Button icon={<LeftOutlined />}>Products</Button>
+        </Link>
+        <Space>
+          <Link to={`/products/edit/${record.id}`}>
+            {/* @ts-expect-error Ant Design Icon's v5.0.1 has an issue with @types/react@^18.2.66 */}
+            <Button icon={<EditOutlined />}>Edit</Button>
+          </Link>
+        </Space>
+      </div>
+      <Descriptions bordered column={1} title={<Text strong>{record.name}</Text>}>
+        <Descriptions.Item label="Internal Reference">
+          {record.internalReference || "-"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Responsible">
+          {record.responsible || "-"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Sales Price">
+          {record.salesPrice}
+        </Descriptions.Item>
+        <Descriptions.Item label="Cost">{record.cost}</Descriptions.Item>
+        <Descriptions.Item label="Quantity On Hand">
+          {record.quantityOnHand}
+        </Descriptions.Item>
+        <Descriptions.Item label="Forecasted Quantity">
+          {record.forecastedQuantity}
+        </Descriptions.Item>
+        <Descriptions.Item label="Unit of Measure">
+          {record.unitOfMeasure}
+        </Descriptions.Item>
+        <Descriptions.Item label="Status">{record.status}</Descriptions.Item>
+      </Descriptions>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add pages for showing and editing products
- wire show and edit routes
- support update operation in product form modal

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a48258d08331a961812b5ababf06